### PR TITLE
[feat] 카카오 소셜 로그인 구현 (#4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,14 @@ dependencies {
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/src/main/java/teamficial/teamficial_be/TeamficialBeApplication.java
+++ b/src/main/java/teamficial/teamficial_be/TeamficialBeApplication.java
@@ -2,7 +2,9 @@ package teamficial.teamficial_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TeamficialBeApplication {
 

--- a/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
@@ -1,10 +1,7 @@
 package teamficial.teamficial_be.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package teamficial.teamficial_be.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import teamficial.teamficial_be.domain.auth.dto.KakaoResponseDTO;
+import teamficial.teamficial_be.domain.auth.service.AuthService;
+import teamficial.teamficial_be.global.apiPayload.ApiResponse;
+import teamficial.teamficial_be.global.security.jwt.TokenProvider;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final TokenProvider tokenProvider;
+
+    @PostMapping("/auth/kakao")
+    @Operation(summary = "카카오 로그인", description = "인가 코드를 통해 토큰을 발급받는 카카오 로그인 API입니다.")
+    public ApiResponse<KakaoResponseDTO.LoginTokenResponseDto> kakaoLogin(@RequestParam("code")String accessCode,@RequestParam("redirectUri") String redirectUri){
+        return ApiResponse.onSuccess(authService.kakaoLogin(accessCode,redirectUri));
+    }
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/auth/dto/KakaoResponseDTO.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/dto/KakaoResponseDTO.java
@@ -1,0 +1,29 @@
+package teamficial.teamficial_be.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class KakaoResponseDTO {
+
+    @Getter
+    @AllArgsConstructor
+    public static class LoginTokenResponseDto {
+        @Schema(description = "사용자 id", example="1")
+        private Long userId;
+        @Schema(description = "사용자 accessToken", example="exksoijsdjon...")
+        private String accessToken;
+        @Schema(description = "사용자 refreshToken", example="exjnasoicjkdd...")
+        private String refreshToken;
+        @Schema(description = "사용자 최초 로그인 여부(처음이면 true)", example="true")
+        private boolean isFirst;
+
+        public static LoginTokenResponseDto of(Long userId,String accessToken,String refreshToken,boolean isFirst) {
+            return new LoginTokenResponseDto(
+                    userId,
+                    accessToken,
+                    refreshToken,
+                    isFirst);
+        }
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
@@ -1,0 +1,63 @@
+package teamficial.teamficial_be.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import teamficial.teamficial_be.domain.auth.dto.KakaoResponseDTO;
+import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.domain.user.entity.UserRole;
+import teamficial.teamficial_be.domain.user.repository.UserRepository;
+import teamficial.teamficial_be.global.security.dto.TokenResponse;
+import teamficial.teamficial_be.global.security.jwt.TokenProvider;
+import teamficial.teamficial_be.global.security.kakao.KakaoDTO;
+import teamficial.teamficial_be.global.security.kakao.KakaoUtil;
+import teamficial.teamficial_be.global.redis.RedisService;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final KakaoUtil kakaoUtil;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final PasswordEncoder passwordEncoder;
+    private final RedisService redisService;
+
+    public KakaoResponseDTO.LoginTokenResponseDto kakaoLogin(String accessCode, String redirectUri){
+        KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode,redirectUri);
+        KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
+
+        String email = kakaoProfile.getKakao_account().getEmail();
+        String name = kakaoProfile.getProperties().getNickname();
+
+        AtomicBoolean isFirst = new AtomicBoolean(false);
+
+        User user = userRepository.findByEmailAndDeletedAtIsNull(email)
+                .map(existingUser -> existingUser)
+                .orElseGet(() -> {
+                    isFirst.set(true);
+                    return createUser(email, name);
+                });
+
+        TokenResponse tokenResponse = tokenProvider.createToken(user);
+        redisService.setRefreshToken(user.getEmail(),tokenResponse.getRefreshToken());
+
+        return KakaoResponseDTO.LoginTokenResponseDto.of(user.getId(),tokenResponse.getAccessToken(),tokenResponse.getRefreshToken(),isFirst.get());
+    }
+
+    private User createUser(String email, String name) {
+        String rawPassword = UUID.randomUUID().toString();
+
+        User user =User.builder()
+                .email(email)
+                .userName(name)
+                .password(passwordEncoder.encode(rawPassword))
+                .userRole(UserRole.USER)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
 
         User user =User.builder()
                 .email(email)
-                .userName(name)
+                .name(name)
                 .password(passwordEncoder.encode(rawPassword))
                 .userRole(UserRole.USER)
                 .build();

--- a/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
@@ -1,27 +1,33 @@
 package teamficial.teamficial_be.domain.user.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import teamficial.teamficial_be.global.entity.BaseEntity;
 
 
 @Entity
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class User extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
+    @Column(nullable = false, unique = true, length = 50)
     private String email;
 
-    private String userName;
+    @Column(nullable = false,length = 20)
+    private String name;
 
     private String password;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role")
     private UserRole userRole;
 
 

--- a/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
@@ -1,0 +1,22 @@
+package teamficial.teamficial_be.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class User {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userName;
+
+    private String password;
+
+    private UserRole userRole;
+
+    boolean isDeleted=false;
+}

--- a/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
@@ -4,13 +4,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
+import teamficial.teamficial_be.global.entity.BaseEntity;
+
 
 @Entity
 @Getter
-public class User {
+@Builder
+public class User extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String email;
 
     private String userName;
 
@@ -18,5 +24,5 @@ public class User {
 
     private UserRole userRole;
 
-    boolean isDeleted=false;
+
 }

--- a/src/main/java/teamficial/teamficial_be/domain/user/entity/UserRole.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/entity/UserRole.java
@@ -1,0 +1,6 @@
+package teamficial.teamficial_be.domain.user.entity;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/teamficial/teamficial_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package teamficial.teamficial_be.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamficial.teamficial_be.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/teamficial/teamficial_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/repository/UserRepository.java
@@ -3,5 +3,7 @@ package teamficial.teamficial_be.domain.user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import teamficial.teamficial_be.domain.user.entity.User;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
-}
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);}

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -15,8 +15,13 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    REDIS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_ERROR", "Redis 설정에 오류가 발생했습니다."),
 
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
+    NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND,"TOKEN404","토큰을 찾을 수 없습니다."),
+
+    //로그인 관련 응답
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "TOKEN4001", "토큰이 유효하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package teamficial.teamficial_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private Integer port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package teamficial.teamficial_be.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import teamficial.teamficial_be.global.security.jwt.JwtAuthenticationFilter;
+import teamficial.teamficial_be.global.security.jwt.JwtExceptionFilter;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api",
+                                "/api/swagger-ui/**"
+                        ).permitAll()
+                        //.requestMatchers().authenticated()
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("http://localhost:8080");
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -36,6 +38,13 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .logoutSuccessHandler(logoutSuccessHandler())
+                        .clearAuthentication(true)
+                        .permitAll()
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api",
@@ -65,5 +74,10 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public LogoutSuccessHandler logoutSuccessHandler() {
+        return new HttpStatusReturningLogoutSuccessHandler();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/dto/TokenResponseDTO.java
+++ b/src/main/java/teamficial/teamficial_be/global/dto/TokenResponseDTO.java
@@ -1,0 +1,19 @@
+package teamficial.teamficial_be.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class TokenResponseDTO {
+
+    @Getter
+    @AllArgsConstructor
+    public static class RefreshTokenResponseDto {
+        private Long userId;
+        private String accessToken;
+        private String refreshToken;
+
+        public static RefreshTokenResponseDto of(Long userId, String accessToken,String refreshToken) {
+            return new RefreshTokenResponseDto(userId, accessToken,refreshToken);
+        }
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/entity/BaseEntity.java
+++ b/src/main/java/teamficial/teamficial_be/global/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package teamficial.teamficial_be.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
+
+    public void markAsDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/redis/RedisService.java
+++ b/src/main/java/teamficial/teamficial_be/global/redis/RedisService.java
@@ -1,0 +1,60 @@
+package teamficial.teamficial_be.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Value("${jwt.token.refresh-expiration-time}")
+    private long refreshTokenExpirationTime;
+
+    @Value("${jwt.token.access-expiration-time}")
+    private long accessExpirationTime;
+
+    public void setRefreshToken(String key, String value) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            values.set(key, value, Duration.ofMillis(refreshTokenExpirationTime));
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.REDIS_ERROR);
+        }
+    }
+
+    public String getValue(String key) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            if (values.get(key) == null) {
+                return "";
+            }
+            return values.get(key).toString();
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.REDIS_ERROR);
+        }
+    }
+
+    public void deleteValue(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.REDIS_ERROR);
+        }
+    }
+
+    public boolean checkExistsValue(String key) {
+        try {
+            return redisTemplate.hasKey(key);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.REDIS_ERROR);
+        }
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
@@ -46,6 +46,6 @@ public record AuthDetails(User user) implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return user.getDeletedAt().equals(null);
+        return user.getDeletedAt() == null;
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
@@ -1,0 +1,51 @@
+package teamficial.teamficial_be.global.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import teamficial.teamficial_be.domain.user.entity.User;
+
+import java.util.Collection;
+import java.util.List;
+
+public record AuthDetails(User user) implements UserDetails {
+
+    public AuthDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getUserRole().toString()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return user.isDeleted();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
@@ -26,7 +26,7 @@ public record AuthDetails(User user) implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getUserName();
+        return user.getName();
     }
 
     @Override

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
@@ -46,6 +46,6 @@ public record AuthDetails(User user) implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return user.isDeleted();
+        return user.getDeletedAt().equals(null);
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetailsService.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetailsService.java
@@ -1,0 +1,27 @@
+package teamficial.teamficial_be.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.domain.user.repository.UserRepository;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.handler.NotFoundHandler;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+        return new AuthDetails(user);
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetailsService.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetailsService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.domain.user.repository.UserRepository;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 import teamficial.teamficial_be.global.apiPayload.exception.handler.NotFoundHandler;
 
 @Service
@@ -20,8 +21,13 @@ public class AuthDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        User user = userRepository.findById(Long.valueOf(userId))
-                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
-        return new AuthDetails(user);
+        try {
+            Long id = Long.valueOf(userId);
+            User user = userRepository.findById(id)
+                    .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+            return new AuthDetails(user);
+        } catch (NumberFormatException e){
+            throw new GeneralException(ErrorStatus.TOKEN_INVALID);
+        }
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/security/TokenProvider.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/TokenProvider.java
@@ -1,0 +1,133 @@
+package teamficial.teamficial_be.global.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.global.dto.TokenResponseDTO;
+
+import java.security.Key;
+import java.util.Date;
+
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider implements InitializingBean {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+    private Key key;
+
+    @Value("${jwt.token.access-expiration-time}")
+    private long accessExpirationTime;
+
+    @Value("${jwt.token.refresh-expiration-time}")
+    private long refreshExpirationTime;
+
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public void afterPropertiesSet(){
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(User user) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + accessExpirationTime);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + refreshExpirationTime);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(key,SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public TokenResponseDTO.RefreshTokenResponseDto recreate(User user, String refreshToken) {
+        String accessToken = createAccessToken(user);
+
+        if(getExpirationTime(refreshToken) <= getExpirationTime(accessToken)) {
+            refreshToken = createRefreshToken(user);
+        }
+
+        return TokenResponseDTO.RefreshTokenResponseDto.of(user.getId(),accessToken,refreshToken);
+    }
+
+    public Long getExpirationTime(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration()
+                .getTime();
+    }
+
+    public String getAccessToken(HttpServletRequest request){
+        String token = request.getHeader("Authorization");
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+
+    //userId 추출
+    public String getUserIdFromToken(String token){
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public Authentication getAuthentication(String token){
+        UserDetails userDetails =
+                (UserDetails)
+                        userDetailsService.loadUserByUsername(getUserIdFromToken(token));
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, token, userDetails.getAuthorities());
+    }
+
+    public boolean validateToken(String token){
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException ex) {
+            throw new IllegalArgumentException("Invalid JWT signature or token malformed: "+ ex.getMessage());
+        } catch (ExpiredJwtException ex) {
+            throw new IllegalArgumentException("Expired JWT token: "+ ex.getMessage());
+        } catch (UnsupportedJwtException ex) {
+            throw new IllegalArgumentException("Unsupported JWT token: "+ ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("JWT token compact of null or empty: "+ ex.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/dto/TokenResponse.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/dto/TokenResponse.java
@@ -1,0 +1,21 @@
+package teamficial.teamficial_be.global.security.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+
+    @Schema(description = "Access Token")
+    private String accessToken;
+
+    @Schema(description = "Refresh Token")
+    private String refreshToken;
+
+    public TokenResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/dto/TokenResponseDTO.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/dto/TokenResponseDTO.java
@@ -1,4 +1,4 @@
-package teamficial.teamficial_be.global.dto;
+package teamficial.teamficial_be.global.security.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/teamficial/teamficial_be/global/security/entity/RefreshToken.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/entity/RefreshToken.java
@@ -5,7 +5,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
-@RedisHash(value = "refreshToken", timeToLive = 14440)
+@RedisHash(value = "refreshToken", timeToLive = 604800000)
 public class RefreshToken {
     @Id
     private String refreshToken;

--- a/src/main/java/teamficial/teamficial_be/global/security/entity/RefreshToken.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/entity/RefreshToken.java
@@ -1,0 +1,18 @@
+package teamficial.teamficial_be.global.security.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 14440)
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private Long userId;
+
+    public RefreshToken(String refreshToken, Long userId) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package teamficial.teamficial_be.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import teamficial.teamficial_be.global.security.TokenProvider;
+
+import java.io.IOException;
+
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = tokenProvider.getAccessToken(request);
+
+        if (token != null && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+
+            if (authentication != null) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import teamficial.teamficial_be.global.security.TokenProvider;
 
 import java.io.IOException;
 

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 
 import java.io.IOException;
 
@@ -25,11 +27,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = tokenProvider.resolveToken(request);
 
-        if (token != null && tokenProvider.validateToken(token)) {
-            Authentication authentication = tokenProvider.getAuthentication(token);
+        if (token != null) {
+            try{
+                Authentication authentication = tokenProvider.getAuthentication(token);
 
-            if (authentication != null) {
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                if (authentication != null) {
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }catch (IllegalArgumentException e){
+                throw new GeneralException(ErrorStatus.TOKEN_INVALID);
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String token = tokenProvider.getAccessToken(request);
+        String token = tokenProvider.resolveToken(request);
 
         if (token != null && tokenProvider.validateToken(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,45 @@
+package teamficial.teamficial_be.global.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (GeneralException e) {
+            setErrorResponse(response,e.getErrorReasonHttpStatus().getHttpStatus().value(),e.getErrorReasonHttpStatus().getCode(),e.getErrorReasonHttpStatus().getMessage());
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, int status,String code, String message) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status);
+
+        String json = objectMapper.writeValueAsString(Map.of(
+                "isSuccess", false,
+                "code", code,
+                "message", message
+        ));
+
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/TokenProvider.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/TokenProvider.java
@@ -1,4 +1,4 @@
-package teamficial.teamficial_be.global.security;
+package teamficial.teamficial_be.global.security.jwt;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;

--- a/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoDTO.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoDTO.java
@@ -1,0 +1,45 @@
+package teamficial.teamficial_be.global.security.kakao;
+
+import lombok.Getter;
+
+public class KakaoDTO {
+    @Getter
+    public static class OAuthToken{
+        private String access_token;
+        private String token_type;
+        private String refresh_token;
+        private int expires_in;
+        private String scope;
+        private int refresh_token_expires_in;
+    }
+
+    @Getter
+    public static class KakaoProfile {
+        private Long id;
+        private String connected_at;
+        private Properties properties;
+        private KakaoAccount kakao_account;
+
+        @Getter
+        public static class Properties {
+            private String nickname;
+        }
+
+        @Getter
+        public static class KakaoAccount {
+            private String email;
+            private Boolean is_email_verified;
+            private Boolean has_email;
+            private Boolean profile_nickname_needs_agreement;
+            private Boolean email_needs_agreement;
+            private Boolean is_email_valid;
+            private Profile profile;
+
+            @Getter
+            public static class Profile {
+                private String nickname;
+                private Boolean is_default_nickname;
+            }
+        }
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
@@ -1,0 +1,66 @@
+package teamficial.teamficial_be.global.security.kakao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+public class KakaoUtil {
+    @Value("${spring.security.oauth2.client.registration.kakao.client_id}")
+    private String client;
+    @Value("$spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirect;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoUri;
+
+    private final RestClient restClient = RestClient.create();
+    private final ObjectMapper objectMapper;
+
+    public KakaoDTO.OAuthToken requestToken(String accessCode) {
+        String response = restClient.post()
+                        .uri(uriBuilder -> uriBuilder
+                                .scheme("https")
+                                .host("kauth.kakao.com")
+                                .path("/oauth/token")
+                                .queryParam("grant_type", "authorization_code")
+                                .queryParam("client_id",client)
+                                .queryParam("code", accessCode)
+                                .queryParam("redirect_uri", redirect)
+                                .queryParam("client_secret", clientSecret)
+                                .build())
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .retrieve()
+                .body(String.class);
+
+        try {
+            return objectMapper.readValue(response, KakaoDTO.OAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse Kakao access token", e);
+        }
+    }
+
+    public KakaoDTO.KakaoProfile requestProfile(KakaoDTO.OAuthToken oAuthToken) {
+        RestTemplate restTemplate2 = new RestTemplate();
+        HttpHeaders headers2 = new HttpHeaders();
+
+        String response = restClient.get()
+                .uri(userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + oAuthToken.getAccess_token())
+                .retrieve()
+                .body(String.class);
+
+        try {
+            KakaoDTO.KakaoProfile kakaoProfile = objectMapper.readValue(response, KakaoDTO.KakaoProfile.class);
+            return kakaoProfile;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse Kakao access token", e);
+        }
+    }
+
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
+@Component
 @RequiredArgsConstructor
 public class KakaoUtil {
     @Value("${spring.security.oauth2.client.registration.kakao.client_id}")
     private String client;
-    @Value("$spring.security.oauth2.client.registration.kakao.redirect-uri}")
-    private String redirect;
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
@@ -22,7 +22,7 @@ public class KakaoUtil {
     private final RestClient restClient = RestClient.create();
     private final ObjectMapper objectMapper;
 
-    public KakaoDTO.OAuthToken requestToken(String accessCode) {
+    public KakaoDTO.OAuthToken requestToken(String accessCode,String redirect) {
         String response = restClient.post()
                         .uri(uriBuilder -> uriBuilder
                                 .scheme("https")

--- a/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
@@ -23,18 +25,17 @@ public class KakaoUtil {
     private final ObjectMapper objectMapper;
 
     public KakaoDTO.OAuthToken requestToken(String accessCode,String redirect) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_uri", redirect);
+        params.add("code", accessCode);
+        params.add("client_secret", clientSecret);
+
         String response = restClient.post()
-                        .uri(uriBuilder -> uriBuilder
-                                .scheme("https")
-                                .host("kauth.kakao.com")
-                                .path("/oauth/token")
-                                .queryParam("grant_type", "authorization_code")
-                                .queryParam("client_id",client)
-                                .queryParam("code", accessCode)
-                                .queryParam("redirect_uri", redirect)
-                                .queryParam("client_secret", clientSecret)
-                                .build())
+                .uri("https://kauth.kakao.com/oauth/token")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .body(params)
                 .retrieve()
                 .body(String.class);
 

--- a/src/main/java/teamficial/teamficial_be/global/security/repository/RefreshTokenRepository.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package teamficial.teamficial_be.global.security.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import teamficial.teamficial_be.global.security.entity.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #4 

## 📝작업 내용

> JWT 토큰 발급 로직 + Oauth를 이용한 카카오 소셜 로그인 구현

- [x] JWT 토큰 발급 로직 구현
- [x] 카카오 소셜 로그인 구현

이어서 구글로그인, 네이버 로그인 구현을 해야해서 기본적인 세팅만 하고 pr올립니다.
다음 pr에서 로그아웃 + 토큰 재발급 구현하겠습니다.

### 스크린샷
<img width="753" height="203" alt="image" src="https://github.com/user-attachments/assets/030f4fb5-ece1-4a8a-8bb1-de51ac29b0b0" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 토큰 저장할 때 쿠키를 이용할지 (+프론트와 상의 필요)
> redisRepository 형식으로 refreshToken 저장할지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카카오 소셜 로그인 API 추가
  - 로그인 시 액세스/리프레시 토큰 발급 및 만료 시 재발급 지원
  - 로그아웃으로 토큰 무효화 가능
  - 사용자 엔터티 및 역할 기반 인증 지원

- Chores
  - JWT 기반 보안 구성 및 필터 체인 적용, CORS 설정 추가
  - Redis 도입으로 토큰 저장/세션 관리 안정성 향상
  - JPA 감사(auditing) 도입으로 생성/수정/삭제 시각 자동 기록
  - 인증·토큰 관련 오류 코드 확장 및 예외 응답 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->