### PR TITLE
[feat] 구글 소셜 로그인 연동 (#6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	//Oauth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
@@ -19,13 +19,13 @@ public class AuthController {
 
     @PostMapping("/auth/kakao")
     @Operation(summary = "카카오 로그인", description = "인가 코드를 통해 토큰을 발급받는 카카오 로그인 API입니다.")
-    public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> kakaoLogin(@RequestParam("code")String accessCode, @RequestParam("redirectUri") String redirectUri){
+    public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> kakaoLogin(@RequestParam String accessCode, @RequestParam String redirectUri){
         return ApiResponse.onSuccess(authService.kakaoLogin(accessCode,redirectUri));
     }
 
     @PostMapping("/auth/google")
-    @Operation(summary = "구글 로그인",description = "인가 코드를 통해 토큰을 발급받는 카카오 로그인 API입니다.")
-    public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> googleLogin(@RequestParam("code")String accessCode, @RequestParam("redirectUri") String redirectUri){
+    @Operation(summary = "구글 로그인",description = "인가 코드를 통해 토큰을 발급받는 구글 로그인 API입니다.")
+    public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> googleLogin(@RequestParam String accessCode, @RequestParam String redirectUri){
         return ApiResponse.onSuccess(authService.googleLogin(accessCode,redirectUri));
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
@@ -24,6 +24,7 @@ public class AuthController {
     }
 
     @PostMapping("/auth/google")
+    @Operation(summary = "구글 로그인",description = "인가 코드를 통해 토큰을 발급받는 카카오 로그인 API입니다.")
     public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> googleLogin(@RequestParam("code")String accessCode, @RequestParam("redirectUri") String redirectUri){
         return ApiResponse.onSuccess(authService.googleLogin(accessCode,redirectUri));
     }

--- a/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import teamficial.teamficial_be.domain.auth.dto.KakaoResponseDTO;
+import teamficial.teamficial_be.domain.auth.dto.LoginResponseDTO;
 import teamficial.teamficial_be.domain.auth.service.AuthService;
 import teamficial.teamficial_be.global.apiPayload.ApiResponse;
 import teamficial.teamficial_be.global.security.jwt.TokenProvider;
@@ -19,8 +19,13 @@ public class AuthController {
 
     @PostMapping("/auth/kakao")
     @Operation(summary = "카카오 로그인", description = "인가 코드를 통해 토큰을 발급받는 카카오 로그인 API입니다.")
-    public ApiResponse<KakaoResponseDTO.LoginTokenResponseDto> kakaoLogin(@RequestParam("code")String accessCode,@RequestParam("redirectUri") String redirectUri){
+    public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> kakaoLogin(@RequestParam("code")String accessCode, @RequestParam("redirectUri") String redirectUri){
         return ApiResponse.onSuccess(authService.kakaoLogin(accessCode,redirectUri));
+    }
+
+    @PostMapping("/auth/google")
+    public ApiResponse<LoginResponseDTO.LoginTokenResponseDto> googleLogin(@RequestParam("code")String accessCode, @RequestParam("redirectUri") String redirectUri){
+        return ApiResponse.onSuccess(authService.googleLogin(accessCode,redirectUri));
     }
 
 }

--- a/src/main/java/teamficial/teamficial_be/domain/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/dto/LoginResponseDTO.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-public class KakaoResponseDTO {
+public class LoginResponseDTO {
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
@@ -10,7 +10,7 @@ import teamficial.teamficial_be.domain.user.entity.UserRole;
 import teamficial.teamficial_be.domain.user.repository.UserRepository;
 import teamficial.teamficial_be.global.security.dto.TokenResponse;
 import teamficial.teamficial_be.global.security.google.GoogleUtil;
-import teamficial.teamficial_be.global.security.google.dto.GoogleDTO;
+import teamficial.teamficial_be.global.security.google.GoogleDTO;
 import teamficial.teamficial_be.global.security.jwt.TokenProvider;
 import teamficial.teamficial_be.global.security.kakao.KakaoDTO;
 import teamficial.teamficial_be.global.security.kakao.KakaoUtil;

--- a/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
@@ -3,11 +3,14 @@ package teamficial.teamficial_be.domain.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import teamficial.teamficial_be.domain.auth.dto.KakaoResponseDTO;
+import teamficial.teamficial_be.domain.auth.dto.LoginResponseDTO;
+import teamficial.teamficial_be.domain.user.entity.LoginType;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.domain.user.entity.UserRole;
 import teamficial.teamficial_be.domain.user.repository.UserRepository;
 import teamficial.teamficial_be.global.security.dto.TokenResponse;
+import teamficial.teamficial_be.global.security.google.GoogleUtil;
+import teamficial.teamficial_be.global.security.google.dto.GoogleDTO;
 import teamficial.teamficial_be.global.security.jwt.TokenProvider;
 import teamficial.teamficial_be.global.security.kakao.KakaoDTO;
 import teamficial.teamficial_be.global.security.kakao.KakaoUtil;
@@ -20,12 +23,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RequiredArgsConstructor
 public class AuthService {
     private final KakaoUtil kakaoUtil;
+    private final GoogleUtil googleUtil;
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final RedisService redisService;
 
-    public KakaoResponseDTO.LoginTokenResponseDto kakaoLogin(String accessCode, String redirectUri){
+    public LoginResponseDTO.LoginTokenResponseDto kakaoLogin(String accessCode, String redirectUri){
         KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode,redirectUri);
         KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
 
@@ -38,16 +42,16 @@ public class AuthService {
                 .map(existingUser -> existingUser)
                 .orElseGet(() -> {
                     isFirst.set(true);
-                    return createUser(email, name);
+                    return createUser(email, name,LoginType.KAKAO);
                 });
 
         TokenResponse tokenResponse = tokenProvider.createToken(user);
         redisService.setRefreshToken(user.getEmail(),tokenResponse.getRefreshToken());
 
-        return KakaoResponseDTO.LoginTokenResponseDto.of(user.getId(),tokenResponse.getAccessToken(),tokenResponse.getRefreshToken(),isFirst.get());
+        return LoginResponseDTO.LoginTokenResponseDto.of(user.getId(),tokenResponse.getAccessToken(),tokenResponse.getRefreshToken(),isFirst.get());
     }
 
-    private User createUser(String email, String name) {
+    public User createUser(String email, String name, LoginType loginType) {
         String rawPassword = UUID.randomUUID().toString();
 
         User user =User.builder()
@@ -55,9 +59,31 @@ public class AuthService {
                 .name(name)
                 .password(passwordEncoder.encode(rawPassword))
                 .userRole(UserRole.USER)
+                .loginType(loginType)
                 .build();
 
         return userRepository.save(user);
     }
 
+    public LoginResponseDTO.LoginTokenResponseDto googleLogin(String accessCode, String redirectUri) {
+        GoogleDTO.OAuthToken oAuthToken = googleUtil.requestToken(accessCode,redirectUri);
+        GoogleDTO.GoogleProfile googleProfile = googleUtil.getProfile(oAuthToken);
+
+        String email = googleProfile.getEmail();
+        String name = googleProfile.getName();
+
+        AtomicBoolean isFirst = new AtomicBoolean(false);
+
+        User user = userRepository.findByEmailAndDeletedAtIsNull(email)
+                .map(existingUser -> existingUser)
+                .orElseGet(() -> {
+                    isFirst.set(true);
+                    return createUser(email, name,LoginType.GOOGLE);
+                });
+
+        TokenResponse tokenResponse = tokenProvider.createToken(user);
+        redisService.setRefreshToken(user.getEmail(),tokenResponse.getRefreshToken());
+
+        return LoginResponseDTO.LoginTokenResponseDto.of(user.getId(),tokenResponse.getAccessToken(),tokenResponse.getRefreshToken(),isFirst.get());
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/user/entity/LoginType.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/entity/LoginType.java
@@ -1,0 +1,17 @@
+package teamficial.teamficial_be.domain.user.entity;
+
+public enum LoginType {
+    KAKAO("카카오"),
+    GOOGLE("구글"),
+    NAVER("네이버");
+
+    private final String description;
+
+    LoginType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/entity/User.java
@@ -30,5 +30,8 @@ public class User extends BaseEntity {
     @Column(name = "user_role")
     private UserRole userRole;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type")
+    private LoginType loginType;
 
 }

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -21,7 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND,"TOKEN404","토큰을 찾을 수 없습니다."),
 
     //로그인 관련 응답
-    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "TOKEN4001", "토큰이 유효하지 않습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "LOGIN4001", "토큰이 유효하지 않습니다."),
+    LOGIN_TYPE_INVALID(HttpStatus.BAD_REQUEST,"LOGIN4002","로그인 타입이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
                 .oauth2Login(oauth2Login -> oauth2Login
-                        .defaultSuccessUrl("/google-login")
+                        //.defaultSuccessUrl("/")
                         .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
                                 .userService(customOauth2UserService)
                         )

--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import teamficial.teamficial_be.global.security.CustomOauth2UserService;
 import teamficial.teamficial_be.global.security.jwt.JwtAuthenticationFilter;
 import teamficial.teamficial_be.global.security.jwt.JwtExceptionFilter;
 
@@ -28,6 +29,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final CustomOauth2UserService customOauth2UserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -38,6 +40,12 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .defaultSuccessUrl("/google-login")
+                        .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
+                                .userService(customOauth2UserService)
+                        )
+                )
                 .logout(logout -> logout
                         .logoutUrl("/logout")
                         .logoutSuccessUrl("/login?logout")
@@ -72,7 +80,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder(){
+    public static PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
     }
 

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetails.java
@@ -3,15 +3,27 @@ package teamficial.teamficial_be.global.security;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import teamficial.teamficial_be.domain.user.entity.User;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
-public record AuthDetails(User user) implements UserDetails {
+public record AuthDetails(User user, Map<String, Object> attributes) implements UserDetails, OAuth2User {
 
     public AuthDetails(User user) {
-        this.user = user;
+        this(user, Map.of());
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return user.getName();
     }
 
     @Override

--- a/src/main/java/teamficial/teamficial_be/global/security/CustomOauth2UserService.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/CustomOauth2UserService.java
@@ -45,6 +45,8 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                     .password(passwordEncoder.encode(rawPassword))
                     .build();
 
+            userRepository.save(newUser);
+
             return new AuthDetails(newUser, oAuth2User.getAttributes());
         } else {
             return new AuthDetails(user.get(), oAuth2User.getAttributes());

--- a/src/main/java/teamficial/teamficial_be/global/security/CustomOauth2UserService.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/CustomOauth2UserService.java
@@ -1,0 +1,63 @@
+package teamficial.teamficial_be.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import teamficial.teamficial_be.domain.user.entity.LoginType;
+import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.domain.user.entity.UserRole;
+import teamficial.teamficial_be.domain.user.repository.UserRepository;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOauth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        LoginType loginTypeEnum = resolveLoginType(provider);
+        String email = oAuth2User.getAttribute("email");
+        String username = oAuth2User.getAttribute("name");
+        String rawPassword = UUID.randomUUID().toString();
+
+        Optional<User> user = userRepository.findByEmailAndDeletedAtIsNull(email);
+
+        if (user.isEmpty()) {
+            User newUser = User.builder()
+                    .email(email)
+                    .userRole(UserRole.USER)
+                    .loginType(loginTypeEnum)
+                    .name(username)
+                    .password(passwordEncoder.encode(rawPassword))
+                    .build();
+
+            return new AuthDetails(newUser, oAuth2User.getAttributes());
+        } else {
+            return new AuthDetails(user.get(), oAuth2User.getAttributes());
+        }
+
+    }
+
+    private LoginType resolveLoginType(String provider) {
+        return switch (provider.toLowerCase()) {
+            case "google" -> LoginType.GOOGLE;
+            case "naver" -> LoginType.NAVER;
+            case "kakao" -> LoginType.KAKAO;
+            default -> throw new GeneralException(ErrorStatus.LOGIN_TYPE_INVALID);
+        };
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/google/GoogleDTO.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/google/GoogleDTO.java
@@ -1,4 +1,4 @@
-package teamficial.teamficial_be.global.security.google.dto;
+package teamficial.teamficial_be.global.security.google;
 
 import lombok.Getter;
 

--- a/src/main/java/teamficial/teamficial_be/global/security/google/GoogleUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/google/GoogleUtil.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
-import teamficial.teamficial_be.global.security.google.dto.GoogleDTO;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/teamficial/teamficial_be/global/security/google/GoogleUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/google/GoogleUtil.java
@@ -12,6 +12,9 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import teamficial.teamficial_be.global.security.google.dto.GoogleDTO;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 @Component
 @RequiredArgsConstructor
 public class GoogleUtil {
@@ -26,11 +29,13 @@ public class GoogleUtil {
     private String clientSecret;
 
     public GoogleDTO.OAuthToken requestToken(String accessCode, String redirectUri){
+        String code = URLDecoder.decode(accessCode, StandardCharsets.UTF_8);
+
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);
         params.add("redirect_uri", redirectUri);
-        params.add("code", accessCode);
+        params.add("code", code);
         params.add("client_secret", clientSecret);
 
         String response = restClient.post()

--- a/src/main/java/teamficial/teamficial_be/global/security/google/GoogleUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/google/GoogleUtil.java
@@ -1,0 +1,65 @@
+package teamficial.teamficial_be.global.security.google;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import teamficial.teamficial_be.global.security.google.dto.GoogleDTO;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleUtil {
+
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    public GoogleDTO.OAuthToken requestToken(String accessCode, String redirectUri){
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", accessCode);
+        params.add("client_secret", clientSecret);
+
+        String response = restClient.post()
+                .uri("https://oauth2.googleapis.com/token")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .body(params)
+                .retrieve()
+                .body(String.class);
+
+        try {
+            return objectMapper.readValue(response, GoogleDTO.OAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse Google access token", e);
+        }
+    }
+
+    public GoogleDTO.GoogleProfile getProfile(GoogleDTO.OAuthToken token){
+        String response = restClient.get()
+                .uri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.getAccess_token())
+                .retrieve()
+                .body(String.class);
+
+        try {
+            GoogleDTO.GoogleProfile googleProfile = objectMapper.readValue(response, GoogleDTO.GoogleProfile.class);
+            return googleProfile;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse Google user profile response", e);
+        }
+    }
+
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/google/dto/GoogleDTO.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/google/dto/GoogleDTO.java
@@ -1,0 +1,28 @@
+package teamficial.teamficial_be.global.security.google.dto;
+
+import lombok.Getter;
+
+public class GoogleDTO {
+
+    @Getter
+    public static class OAuthToken{
+        private String access_token;
+        private String refresh_token;
+        private int expires_in;
+        private String scope;
+        private String token_type;
+        private String id_token;
+    }
+
+    @Getter
+    public static class GoogleProfile{
+        private String sub;
+        private String name;
+        private String given_name;
+        private String family_name;
+        private String picture;
+        private String email;
+        private boolean email_verified;
+        private String locale;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/kakao/KakaoUtil.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestTemplate;
 
 @Component
 @RequiredArgsConstructor
@@ -47,9 +46,6 @@ public class KakaoUtil {
     }
 
     public KakaoDTO.KakaoProfile requestProfile(KakaoDTO.OAuthToken oAuthToken) {
-        RestTemplate restTemplate2 = new RestTemplate();
-        HttpHeaders headers2 = new HttpHeaders();
-
         String response = restClient.get()
                 .uri(userInfoUri)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + oAuthToken.getAccess_token())
@@ -60,7 +56,7 @@ public class KakaoUtil {
             KakaoDTO.KakaoProfile kakaoProfile = objectMapper.readValue(response, KakaoDTO.KakaoProfile.class);
             return kakaoProfile;
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to parse Kakao access token", e);
+            throw new RuntimeException("Failed to parse Kakao user Profile response", e);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #6 

## 📝작업 내용

> 구글 소셜 로그인 연동했습니다

- [x] 구글 소셜 로그인 연동
- [x] oauth 설정 추가

### 스크린샷 (선택)
<img width="782" height="512" alt="image" src="https://github.com/user-attachments/assets/dcb67632-67ff-4ed8-8fbc-0bdba671ced1" />

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - Google 로그인 추가(/auth/google) 및 OAuth2 소셜 로그인 통합, 최초 로그인 시 자동 회원 생성
  - OAuth2 사용자 처리 서비스와 Google 연동 유틸 도입

- 변경 사항
  - 로그인 응답 형식 통일(LoginResponseDTO)
  - 사용자 엔티티에 로그인 유형(LoginType) 저장 및 인증 상세정보에 OAuth2 속성 포함
  - 시큐리티 OAuth2 로그인 활성화 및 로그아웃 성공 핸들러 추가
  - 비밀번호 인코더 빈을 정적으로 변경

- 오류 코드
  - TOKEN_INVALID 코드 변경("LOGIN4001")
  - 로그인 타입 유효성 오류 추가("LOGIN4002")

- 작업/의존성
  - OAuth2 클라이언트 의존성 추가 (spring-boot-starter-oauth2-client)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->