### PR TITLE
[feat] 로그아웃 구현 (#15)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/controller/AuthController.java
@@ -60,14 +60,15 @@ public class AuthController {
 
     @PostMapping("/auth/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 하는 API입니다.")
-    public ApiResponse<String> logout(HttpServletRequest request, HttpServletResponse response, @AuthenticationPrincipal AuthDetails authDetails) {
+    public ApiResponse<String> logout(HttpServletResponse response, @AuthenticationPrincipal AuthDetails authDetails) {
+
+        if (authDetails == null || authDetails.user() == null) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        authService.logout(authDetails.user());
         cookieUtil.deleteCookie(response);
 
-        String token = tokenProvider.resolveToken(request);
-        if (token == null || token.isEmpty()) {
-            throw new GeneralException(ErrorStatus.NOT_FOUND_TOKEN);
-        }
-        authService.logout(authDetails.user());
         return ApiResponse.onSuccess("로그아웃이 성공했습니다.");
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.auth.dto.LoginResponseDTO;
 import teamficial.teamficial_be.domain.user.entity.LoginType;
 import teamficial.teamficial_be.domain.user.entity.User;
@@ -15,6 +16,7 @@ import teamficial.teamficial_be.global.security.dto.TokenResponse;
 import teamficial.teamficial_be.global.security.dto.TokenResponseDTO;
 import teamficial.teamficial_be.global.security.google.GoogleUtil;
 import teamficial.teamficial_be.global.security.google.GoogleDTO;
+import teamficial.teamficial_be.global.security.jwt.CookieUtil;
 import teamficial.teamficial_be.global.security.jwt.TokenProvider;
 import teamficial.teamficial_be.global.security.kakao.KakaoDTO;
 import teamficial.teamficial_be.global.security.kakao.KakaoUtil;
@@ -112,6 +114,11 @@ public class AuthService {
                 newTokenDTO.getAccessToken(),
                 newTokenDTO.getRefreshToken()
         );
+    }
+
+
+    public void logout(User user) {
+        redisService.deleteValue(REFRESH_TOKEN_PREFIX + user.getId());
     }
 
     private User createUser(String email, String name, LoginType loginType) {

--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import teamficial.teamficial_be.global.apiPayload.exception.handler.OAuth2AuthenticationSuccessHandler;
 import teamficial.teamficial_be.global.security.CustomOauth2UserService;
+import teamficial.teamficial_be.global.security.jwt.CookieUtil;
 import teamficial.teamficial_be.global.security.jwt.JwtAuthenticationFilter;
 import teamficial.teamficial_be.global.security.jwt.JwtExceptionFilter;
 
@@ -51,7 +52,9 @@ public class SecurityConfig {
                         .logoutUrl("/logout")
                         .logoutSuccessUrl("/login?logout")
                         .logoutSuccessHandler(logoutSuccessHandler())
+                        .deleteCookies(CookieUtil.REFRESH_TOKEN_COOKIE_NAME)
                         .clearAuthentication(true)
+                        .invalidateHttpSession(false)
                         .permitAll()
                 )
                 .authorizeHttpRequests(auth -> auth

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/CookieUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/CookieUtil.java
@@ -30,6 +30,7 @@ public class CookieUtil {
         cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setMaxAge(0);
+        cookie.setAttribute("SameSite", "None");
         response.addCookie(cookie);
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/security/jwt/CookieUtil.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/jwt/CookieUtil.java
@@ -1,6 +1,7 @@
 package teamficial.teamficial_be.global.security.jwt;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -18,8 +19,17 @@ public class CookieUtil {
         cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setMaxAge((int) refreshExpirationTime/1000);
+        cookie.setAttribute("SameSite", "None");
 
         return cookie;
     }
 
+    public void deleteCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #15 

## 📝작업 내용

> 로그아웃 구현했습니다.
로직은 아래와 같이 구현했습니다.
1. 쿠키 삭제
2. redis에서 refreshToken 삭제

- [x] 로그아웃 구현

### 스크린샷
<img width="747" height="369" alt="image" src="https://github.com/user-attachments/assets/b8691ec2-2293-4143-ba65-2f264a3abe61" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 로그아웃 엔드포인트 추가: 호출 시 인증 정보 삭제 후 성공 메시지를 반환합니다.
- 버그 수정
  - 로그아웃 시 남아 있던 리프레시 토큰/쿠키를 즉시 무효화해 재인증 동작 일관성 개선.
- Chores
  - 쿠키에 SameSite=None 및 Secure/HttpOnly 적용으로 크로스사이트 호환성 향상.
  - 로그아웃 시 세션/쿠키 정리 동작 구성으로 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->