### PR TITLE
fix: cors 에러 해결 (#17)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOriginPattern("http://localhost:8080");
+        configuration.setAllowedOrigins(List.of("http://localhost:8080","http://localhost:3000"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #17

## 📝작업 내용

> 소셜 로그인 연동 시 cors 에러 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CORS 허용 도메인에 http://localhost:3000을 추가해 로컬 웹 클라이언트의 API 접근 범위를 확대했습니다. 브라우저의 교차 출처 요청에서 8080뿐 아니라 3000 포트의 요청도 정상 승인됩니다. 기존 동작과 기타 보안 정책은 변경되지 않습니다.
- Bug Fixes
  - 일부 로컬 환경에서 CORS 차단으로 발생하던 API 호출 실패 현상을 완화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->