### PR TITLE
[fix] 도메인 추가 (#22)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api",
+                                "/api/",
                                 "/api/swagger-ui/**"
                         ).permitAll()
                         //.requestMatchers().authenticated()
@@ -72,7 +72,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:8080","http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:8080","http://localhost:3000",
+                "http://teamficial.com/", "https://teamficial.com/",
+                "http://api.teamficial.com/","https://api.teamficial.com/",
+                "http://www.teamficial.com/","https://www.teamficial.com/","https://teamficial.vercel.app/"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #22

## 📝작업 내용

> 도메인 배포하면서, securityConfig에 추가하였다.

- [x] securityCOnfig에 도메인 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - 추가 도메인(teamficial.com, api.teamficial.com, www.teamficial.com 및 Vercel 관련 도메인)에서 API 크로스-오리진 접근 지원

* **Chores**
  - API 엔드포인트 접근 패턴 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->