### PR TITLE
[feat] 프로필 관련 링크 수정 & 프로필 리스트 조회 API

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
@@ -3,11 +3,15 @@ package teamficial.teamficial_be.domain.profile.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.profile.service.ProfileService;
 import teamficial.teamficial_be.global.apiPayload.ApiResponse;
+import teamficial.teamficial_be.global.security.AuthDetails;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,8 +27,15 @@ public class ProfileController {
         return ApiResponse.onSuccess(profileResponseDto);
     }
 
+    @GetMapping("/profile")
+    @Operation(summary = "프로필리스트 조회", description = "프로필을 조회하는 API입니다.")
+    public ApiResponse<List<ProfileResponseDto>> getProfileList(@AuthenticationPrincipal AuthDetails authDetails) {
+        List<ProfileResponseDto> profileResponseDtos = profileService.getProfileList(authDetails.user());
+        return ApiResponse.onSuccess(profileResponseDtos);
+    }
+
     @GetMapping("/profile/{profileId}")
-    @Operation(summary = "프로필 조회", description = "프로필을 조회하는 API입니다.")
+    @Operation(summary = "프로필 상세 조회", description = "프로필을 조회하는 API입니다.")
     public ApiResponse<ProfileResponseDto> getProfile(@PathVariable Long profileId) {
         ProfileResponseDto profileResponseDto = profileService.getProfile(profileId);
         return ApiResponse.onSuccess(profileResponseDto);

--- a/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package teamficial.teamficial_be.domain.profile.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
@@ -17,7 +18,7 @@ public class ProfileController {
     @Operation(summary = "프로필 생성", description = "프로필을 생성하는 API입니다.")
     public ApiResponse<ProfileResponseDto> createProfile(@RequestParam Long userId,
                                                          @RequestBody ProfileRequestDto requestDto,
-                                                         @RequestParam String objectKey) {
+                                                         @Nullable @RequestParam String objectKey) {
         ProfileResponseDto profileResponseDto = profileService.createProfile(userId, requestDto, objectKey);
         return ApiResponse.onSuccess(profileResponseDto);
     }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
@@ -20,10 +20,10 @@ public class ProfileController {
 
     @PostMapping("/profile")
     @Operation(summary = "프로필 생성", description = "프로필을 생성하는 API입니다.")
-    public ApiResponse<ProfileResponseDto> createProfile(@RequestParam Long userId,
+    public ApiResponse<ProfileResponseDto> createProfile(@AuthenticationPrincipal AuthDetails authDetails,
                                                          @RequestBody ProfileRequestDto requestDto,
                                                          @Nullable @RequestParam String objectKey) {
-        ProfileResponseDto profileResponseDto = profileService.createProfile(userId, requestDto, objectKey);
+        ProfileResponseDto profileResponseDto = profileService.createProfile(authDetails.user(), requestDto, objectKey);
         return ApiResponse.onSuccess(profileResponseDto);
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/request/ProfileRequestDto.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
 import teamficial.teamficial_be.global.enums.Position;
 
+import java.util.List;
+
 @Getter
 public class ProfileRequestDto {
     @Schema(description = "프로필 이름", example="1")
@@ -18,8 +20,8 @@ public class ProfileRequestDto {
     @Schema(description = "근무 시간대", example="MORNING")
     @NotNull(message = "근무 시간대는 필수입니다.")
     private WorkingTime workingTime;
-    @Schema(description = "관련 링크")
-    private String link;
+    @Schema(description = "관련 링크들")
+    private List<String> links;
     @Schema(description = "연락 수단", example="오픈채팅방 링크")
     private String contactWay;
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
@@ -28,7 +28,7 @@ public class ProfileResponseDto {
     private String profileName;
     @Schema(description = "프로필 파트", example="프론트엔드")
     private String position;
-    @Schema(description = "사용자 id", example="아침")
+    @Schema(description = "근무 시간대", example="아침")
     private String workingTime;
     @Schema(description = "관련 링크")
     private List<String> links;

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
@@ -5,10 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.domain.profile.entity.ProfileLink;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
 import teamficial.teamficial_be.global.enums.Position;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -28,13 +31,17 @@ public class ProfileResponseDto {
     @Schema(description = "사용자 id", example="아침")
     private String workingTime;
     @Schema(description = "관련 링크")
-    private String link;
+    private List<String> links;
     @Schema(description = "연락 수단", example="오픈채팅방 링크")
     private String contactWay;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
     public static ProfileResponseDto of(Profile profile) {
+        List<String> linkList = profile.getProfileLinks().stream()
+                .map(ProfileLink::getLink)
+                .collect(Collectors.toList());
+
         return ProfileResponseDto.builder()
                 .profileId(profile.getId())
                 .userId(profile.getUser().getId())
@@ -43,7 +50,7 @@ public class ProfileResponseDto {
                 .profileImageUrl(profile.getProfileImage())
                 .position(profile.getPosition().getDescription())
                 .workingTime(profile.getWorkingTime().getDescription())
-                .link(profile.getLink())
+                .links(linkList)
                 .contactWay(profile.getContactWay())
                 .createdAt(profile.getCreatedAt())
                 .modifiedAt(profile.getUpdatedAt())

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
@@ -75,7 +75,6 @@ public class Profile extends BaseEntity {
     }
 
     public void clearLinks() {
-        this.profileLinks.forEach(pl -> pl.clearProfile());
         this.profileLinks.clear();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
@@ -10,6 +10,9 @@ import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.entity.BaseEntity;
 import teamficial.teamficial_be.global.enums.Position;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -42,8 +45,9 @@ public class Profile extends BaseEntity {
     @Column(name = "working_time", nullable = false)
     private WorkingTime workingTime;
 
-    @Column(name = "link", length = 255)
-    private String link;
+    @OneToMany(mappedBy = "profile",cascade = CascadeType.ALL,orphanRemoval = true)
+    @Builder.Default
+    private List<ProfileLink> profileLinks= new ArrayList<>();
 
     @Column(name = "contact_way", length = 255)
     private String contactWay;
@@ -52,7 +56,6 @@ public class Profile extends BaseEntity {
         this.profileName = dto.getProfileName();
         this.position = dto.getPosition();
         this.workingTime = dto.getWorkingTime();
-        this.link = dto.getLink();
         this.contactWay = dto.getContactWay();
     }
 
@@ -62,5 +65,17 @@ public class Profile extends BaseEntity {
 
     public void deleteProfileImage(){
         this.profileImage = null;
+    }
+    public void addLink(String link) {
+        ProfileLink newProfileLink = ProfileLink.builder()
+                .profile(this)
+                .link(link)
+                .build();
+        profileLinks.add(newProfileLink);
+    }
+
+    public void clearLinks() {
+        this.profileLinks.forEach(pl -> pl.clearProfile());
+        this.profileLinks.clear();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/ProfileLink.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/ProfileLink.java
@@ -1,0 +1,27 @@
+package teamficial.teamficial_be.domain.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id", nullable = false)
+    private Profile profile;
+
+    @Column(name = "link", length = 255)
+    private String link;
+
+    public void clearProfile() {
+        this.profile = null;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/ProfileLink.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/ProfileLink.java
@@ -21,7 +21,4 @@ public class ProfileLink {
     @Column(name = "link", length = 255)
     private String link;
 
-    public void clearProfile() {
-        this.profile = null;
-    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
@@ -2,6 +2,10 @@ package teamficial.teamficial_be.domain.profile.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.domain.user.entity.User;
+
+import java.util.List;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    List<Profile> findAllByUser(User user);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.domain.profile.entity.ProfileLink;
 import teamficial.teamficial_be.domain.profile.repository.ProfileRepository;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.domain.user.service.UserService;
@@ -31,9 +32,12 @@ public class ProfileService {
                 .workingTime(requestDto.getWorkingTime())
                 .profileName(requestDto.getProfileName())
                 .contactWay(requestDto.getContactWay())
-                .link(requestDto.getLink())
                 .profileImage(imageUrl)
                 .build();
+
+        if (requestDto.getLinks() != null) {
+            requestDto.getLinks().forEach(link -> profile.addLink(link));
+        }
 
         profileRepository.save(profile);
         return ProfileResponseDto.of(profile);
@@ -43,6 +47,12 @@ public class ProfileService {
     public ProfileResponseDto updateProfile(Long profileId, ProfileRequestDto requestDto){
         Profile profile = getProfileById(profileId);
         profile.update(requestDto);
+
+        profile.clearLinks();
+        if (requestDto.getLinks() != null) {
+            requestDto.getLinks().forEach(link -> profile.addLink(link));
+        }
+
         profileRepository.save(profile);
         return ProfileResponseDto.of(profile);
     }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -20,11 +20,9 @@ import java.util.List;
 public class ProfileService {
     private final ProfileRepository profileRepository;
     private final PreSignedUrlService preSignedUrlService;
-    private final UserService userService;
 
     @Transactional
-    public ProfileResponseDto createProfile(Long userId, ProfileRequestDto requestDto, String objectKey){
-        User user = userService.getUserById(userId);
+    public ProfileResponseDto createProfile(User user, ProfileRequestDto requestDto, String objectKey){
         String imageUrl = preSignedUrlService.getPublicUrl(objectKey);
 
         Profile profile = Profile.builder()
@@ -50,8 +48,8 @@ public class ProfileService {
         Profile profile = getProfileById(profileId);
         profile.update(requestDto);
 
-        profile.clearLinks();
         if (requestDto.getLinks() != null) {
+            profile.clearLinks();
             requestDto.getLinks().forEach(link -> profile.addLink(link));
         }
 

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -13,6 +13,8 @@ import teamficial.teamficial_be.domain.user.service.UserService;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
@@ -107,5 +109,13 @@ public class ProfileService {
     public Profile getProfileById(Long profileId){
         return profileRepository.findById(profileId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_PROFILE));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProfileResponseDto> getProfileList(User user) {
+        List<Profile> profiles = profileRepository.findAllByUser(user);
+        return profiles.stream()
+                .map(profile -> ProfileResponseDto.of(profile))
+                .toList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27

## 📝작업 내용

> 프로필 관련 링크가 한 개인 줄 알았는데, 여러 개라서 이에 맞게 엔티티 구조를 수정하였다.
그리고 프로필 리스트를 조회하는 API가 필요하여 이를 구현하였다.

- [x] 프로필 관련 링크 수정
- [x] 프로필 리스트 조회 API 구현

### 스크린샷 (선택)
<img width="786" height="301" alt="image" src="https://github.com/user-attachments/assets/896ad315-613d-4997-82e3-4c41954b9b58" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 릴리스 노트

* **새로운 기능**
  * 사용자의 모든 프로필을 조회할 수 있는 새로운 기능 추가
  * 프로필당 여러 개의 관련 링크 추가 지원 (기존 단일 링크에서 다중 링크로 개선)
  * 프로필 생성 시 선택적 파일 업로드 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->