### PR TITLE
[feat] 내가 지원한 팀 & 지원자 현황 조회 API (#34)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/dto/response/ApplicantListResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/dto/response/ApplicantListResponseDto.java
@@ -1,5 +1,6 @@
 package teamficial.teamficial_be.domain.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
@@ -7,17 +8,22 @@ import teamficial.teamficial_be.domain.profile.entity.Profile;
 @Getter
 @Builder
 public class ApplicantListResponseDto {
+    @Schema(description = "지원 id", example="1")
     private Long applicationId;
+    @Schema(description = "프로필 id", example="1")
     private Long profileId;
-    private String profileName;
+    @Schema(description = "지원자 이름", example="연호")
+    private String applicantName;
+    @Schema(description = "지원자 파트", example="프론트엔드")
     private String profilePosition;
+    @Schema(description = "지원자 프로필 사진")
     private String profileImage;
 
     public static ApplicantListResponseDto from(Long applicationId,Profile profile) {
         return ApplicantListResponseDto.builder()
                 .applicationId(applicationId)
                 .profileId(profile.getId())
-                .profileName(profile.getProfileName())
+                .applicantName(profile.getUserName())
                 .profileImage(profile.getProfileImage())
                 .profilePosition(profile.getPosition().getDescription())
                 .build();

--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -1,9 +1,12 @@
 package teamficial.teamficial_be.domain.application.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
+import teamficial.teamficial_be.domain.user.entity.User;
 
 import java.util.List;
 
@@ -13,4 +16,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     int existsByUserIdAndRecruitingPostId(Long userId, Long recruitingPostId);
 
     List<Application> findAllByRecruitingPost(RecruitingPost recruitingPost);
+
+    Page<Application> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package teamficial.teamficial_be.domain.application.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import teamficial.teamficial_be.domain.application.entity.Application;
@@ -17,5 +18,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     List<Application> findAllByRecruitingPost(RecruitingPost recruitingPost);
 
+    @EntityGraph(attributePaths = {"user"})
     Page<Application> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -1,6 +1,8 @@
 package teamficial.teamficial_be.domain.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import teamficial.teamficial_be.domain.application.dto.ApplicationDTO;
 import teamficial.teamficial_be.domain.application.entity.Application;
@@ -71,8 +73,12 @@ public class ApplicationService {
                 .orElseThrow(()->new NotFoundHandler(ErrorStatus.NOT_FOUND_APPLICAION));
     }
 
-    public List<Application> getApplications(RecruitingPost recruitingPost) {
+    public List<Application> getApplicationsByRecruitingPost(RecruitingPost recruitingPost) {
         return applicationRepository.findAllByRecruitingPost(recruitingPost);
+    }
+
+    public Page<Application> getApplicationsByUser(User user, Pageable pageable) {
+        return applicationRepository.findAllByUser(user,pageable);
     }
 
     public void saveApplication(Application application) {

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
@@ -1,4 +1,4 @@
-package teamficial.teamficial_be.domain.user.controller;
+package teamficial.teamficial_be.domain.myPage.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -6,11 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import teamficial.teamficial_be.domain.application.dto.response.ApplicationResponseDto;
-import teamficial.teamficial_be.domain.user.dto.CurrentApplicationResponseDto;
-import teamficial.teamficial_be.domain.user.service.MypageService;
+import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicantResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicationDetailResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.MyApplicationResponseDto;
+import teamficial.teamficial_be.domain.myPage.service.MypageService;
 import teamficial.teamficial_be.global.apiPayload.ApiResponse;
 import teamficial.teamficial_be.global.enums.Position;
 import teamficial.teamficial_be.global.security.AuthDetails;
+import teamficial.teamficial_be.global.util.PagedResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,12 +22,23 @@ public class MypageController {
 
     private final MypageService mypageService;
 
-    @GetMapping("/my-page/{recruitingPostId}/current-application")
+    @GetMapping("/my-page/applications")
+    @Operation(summary = "내가 지원한 팀 리스트 조회하기", description = "마이페이지에서 내가 지원한 팀들을 조회하는 API입니다.")
+    public ApiResponse<PagedResponse<MyApplicationResponseDto>> getMyPageApplications(@AuthenticationPrincipal AuthDetails authDetails,
+                                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "3") int size) {
+        PagedResponse<MyApplicationResponseDto> responseDtos = mypageService.getAllApplications(authDetails.user(),page,size);
+        return ApiResponse.onSuccess(responseDtos);
+    }
+
+
+
+    @GetMapping("/my-page/{recruitingPostId}/current-applicants")
     @Operation(summary = "지원자 현황 조회", description = "마이페이지에서 지원자 현황을 조회하는 API입니다.")
-    public ApiResponse<CurrentApplicationResponseDto> getCurrentApplication(@PathVariable Long recruitingPostId,
-                                                                            @AuthenticationPrincipal AuthDetails authDetails,
-                                                                            @RequestParam(required = false) Position position) {
-        CurrentApplicationResponseDto responseDto = mypageService.getCurrentApplication(recruitingPostId,authDetails.user(),position);
+    public ApiResponse<CurrentApplicationDetailResponseDto> getCurrentApplication(@PathVariable Long recruitingPostId,
+                                                                                  @AuthenticationPrincipal AuthDetails authDetails,
+                                                                                  @RequestParam(required = false) Position position) {
+        CurrentApplicationDetailResponseDto responseDto = mypageService.getCurrentApplication(recruitingPostId,authDetails.user(),position);
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
@@ -31,7 +31,14 @@ public class MypageController {
         return ApiResponse.onSuccess(responseDtos);
     }
 
-
+    @GetMapping("/my-page/current-applicants")
+    @Operation(summary = "작성한 모집 글들의 지원자 현황 조회하기", description = "마이페이지에서 작성한 모집 글들의 지원자 현황 조회하는 API입니다.")
+    public ApiResponse<PagedResponse<CurrentApplicantResponseDto>> getAllCurrentApplication(@AuthenticationPrincipal AuthDetails authDetails,
+                                                                                            @RequestParam(defaultValue = "0") int page,
+                                                                                            @RequestParam(defaultValue = "3") int size) {
+        PagedResponse<CurrentApplicantResponseDto> responseDtos = mypageService.getAllCurrentApplication(authDetails.user(),page,size);
+        return ApiResponse.onSuccess(responseDtos);
+    }
 
     @GetMapping("/my-page/{recruitingPostId}/current-applicants")
     @Operation(summary = "지원자 현황 조회", description = "마이페이지에서 지원자 현황을 조회하는 API입니다.")

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
@@ -1,0 +1,36 @@
+package teamficial.teamficial_be.domain.myPage.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class CurrentApplicantResponseDto {
+    private Long recruitingPostId;
+    private String writerName;
+    private String title;
+    private List<String> tags;
+    private LocalDateTime deadline;
+    private int totalApplicants;
+    private LocalDateTime createdAt;
+
+    public static CurrentApplicantResponseDto of(RecruitingPost recruitingPost) {
+        List<String> tags = recruitingPost.getRecruitingDetails().stream()
+                .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
+                .toList();
+
+        return CurrentApplicantResponseDto.builder()
+                .recruitingPostId(recruitingPost.getId())
+                .title(recruitingPost.getTitle())
+                .writerName(recruitingPost.getProfile().getProfileName())
+                .totalApplicants(recruitingPost.getTotalApplicants())
+                .tags(tags)
+                .deadline(recruitingPost.getDeadline())
+                .createdAt(recruitingPost.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class CurrentApplicantResponseDto {
     private Long recruitingPostId;
     private String writerName;
+    private String profileImage;
     private String title;
     private List<String> tags;
     private LocalDateTime deadline;
@@ -26,7 +27,8 @@ public class CurrentApplicantResponseDto {
         return CurrentApplicantResponseDto.builder()
                 .recruitingPostId(recruitingPost.getId())
                 .title(recruitingPost.getTitle())
-                .writerName(recruitingPost.getProfile().getProfileName())
+                .profileImage(recruitingPost.getProfile().getProfileImage())
+                .writerName(recruitingPost.getProfile().getUserName())
                 .totalApplicants(recruitingPost.getTotalApplicants())
                 .tags(tags)
                 .deadline(recruitingPost.getDeadline())

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
@@ -1,5 +1,6 @@
 package teamficial.teamficial_be.domain.myPage.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
@@ -10,13 +11,21 @@ import java.util.List;
 @Getter
 @Builder
 public class CurrentApplicantResponseDto {
+    @Schema(description = "모집 글 id", example="1")
     private Long recruitingPostId;
+    @Schema(description = "작성자 이름", example="연호")
     private String writerName;
+    @Schema(description = "작성자 프로필 사진")
     private String profileImage;
+    @Schema(description = "모집 글 제목", example="팀피셜 팀원 모집합니다.")
     private String title;
+    @Schema(description = "작성 글의 모집 파트", example="[\"프론트엔드\",\n\"백엔드\"]")
     private List<String> tags;
+    @Schema(description = "공고 마감일", example="2025-10-28T06:38:03.179Z")
     private LocalDateTime deadline;
+    @Schema(description = "총 지원자 수", example="3")
     private int totalApplicants;
+    @Schema(description = "글 작성일", example="2025-10-28T06:38:03.179Z")
     private LocalDateTime createdAt;
 
     public static CurrentApplicantResponseDto of(RecruitingPost recruitingPost) {

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicationDetailResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicationDetailResponseDto.java
@@ -1,6 +1,5 @@
-package teamficial.teamficial_be.domain.user.dto;
+package teamficial.teamficial_be.domain.myPage.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import teamficial.teamficial_be.domain.application.dto.response.ApplicantListResponseDto;
@@ -13,12 +12,12 @@ import java.util.List;
 
 @Builder
 @Getter
-public class CurrentApplicationResponseDto {
+public class CurrentApplicationDetailResponseDto {
     private RecruitingPostResponseDto recruitingPost;
     private List<ApplicantListResponseDto> applicantList;
 
-    public static CurrentApplicationResponseDto from(RecruitingPost recruitingPost, List<Application> applications) {
-        return CurrentApplicationResponseDto.builder()
+    public static CurrentApplicationDetailResponseDto from(RecruitingPost recruitingPost, List<Application> applications) {
+        return CurrentApplicationDetailResponseDto.builder()
                 .recruitingPost(RecruitingPostResponseDto.from(recruitingPost))
                 .applicantList(applications.stream()
                         .map(application -> ApplicantListResponseDto.from(application.getId(), application.getProfile()))

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyApplicationResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyApplicationResponseDto.java
@@ -1,0 +1,38 @@
+package teamficial.teamficial_be.domain.myPage.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class MyApplicationResponseDto {
+    private Long recruitingPostId;
+    private String writerName;
+    private String title;
+    private List<String> tags;
+    private String status;
+    private String period;
+    private LocalDateTime deadline;
+    private LocalDateTime createdAt;
+
+    public static MyApplicationResponseDto of(RecruitingPost recruitingPost) {
+        List<String> tags = recruitingPost.getRecruitingDetails().stream()
+                .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
+                .toList();
+
+        return MyApplicationResponseDto.builder()
+                .recruitingPostId(recruitingPost.getId())
+                .title(recruitingPost.getTitle())
+                .writerName(recruitingPost.getProfile().getProfileName())
+                .status(recruitingPost.getStatus().getDescription())
+                .tags(tags)
+                .period(recruitingPost.getPeriod().getDescription())
+                .deadline(recruitingPost.getDeadline())
+                .createdAt(recruitingPost.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyApplicationResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyApplicationResponseDto.java
@@ -1,5 +1,6 @@
 package teamficial.teamficial_be.domain.myPage.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
@@ -10,17 +11,26 @@ import java.util.List;
 @Getter
 @Builder
 public class MyApplicationResponseDto {
+    @Schema(description = "모집 글 id", example="1")
     private Long recruitingPostId;
+    @Schema(description = "작성자 이름", example="연호")
     private String writerName;
+    @Schema(description = "작성자 프로필 사진")
     private String profileImage;
+    @Schema(description = "모집 글 제목", example="팀피셜 팀원 모집합니다.")
     private String title;
+    @Schema(description = "모집 글의 모집 파트", example="[\"프론트엔드\",\n\"백엔드\"]")
     private List<String> tags;
+    @Schema(description = "지원 상태", example="참여 확정")
     private String status;
+    @Schema(description = "프로젝트 진행 기간", example="1개월 이내")
     private String period;
+    @Schema(description = "공고 마감일", example="2025-10-28T06:38:03.179Z")
     private LocalDateTime deadline;
+    @Schema(description = "글 작성일", example="2025-10-28T06:38:03.179Z")
     private LocalDateTime createdAt;
 
-    public static MyApplicationResponseDto of(RecruitingPost recruitingPost) {
+    public static MyApplicationResponseDto of(RecruitingPost recruitingPost, String applicationStatus) {
         List<String> tags = recruitingPost.getRecruitingDetails().stream()
                 .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
                 .toList();
@@ -29,7 +39,7 @@ public class MyApplicationResponseDto {
                 .recruitingPostId(recruitingPost.getId())
                 .title(recruitingPost.getTitle())
                 .writerName(recruitingPost.getProfile().getUserName())
-                .status(recruitingPost.getStatus().getDescription())
+                .status(applicationStatus)
                 .profileImage(recruitingPost.getProfile().getProfileImage())
                 .tags(tags)
                 .period(recruitingPost.getPeriod().getDescription())

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyApplicationResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyApplicationResponseDto.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class MyApplicationResponseDto {
     private Long recruitingPostId;
     private String writerName;
+    private String profileImage;
     private String title;
     private List<String> tags;
     private String status;
@@ -27,8 +28,9 @@ public class MyApplicationResponseDto {
         return MyApplicationResponseDto.builder()
                 .recruitingPostId(recruitingPost.getId())
                 .title(recruitingPost.getTitle())
-                .writerName(recruitingPost.getProfile().getProfileName())
+                .writerName(recruitingPost.getProfile().getUserName())
                 .status(recruitingPost.getStatus().getDescription())
+                .profileImage(recruitingPost.getProfile().getProfileImage())
                 .tags(tags)
                 .period(recruitingPost.getPeriod().getDescription())
                 .deadline(recruitingPost.getDeadline())

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -45,7 +45,17 @@ public class MypageService {
         return PagedResponse.of(dtoPage);
     }
 
+    @Transactional(readOnly = true)
+    public PagedResponse<CurrentApplicantResponseDto> getAllCurrentApplication(User user, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "deadline"));
 
+        Page<RecruitingPost> recruitingPostPage = recruitingPostService.getAllRecruitingPostsByUser(user.getId(),pageable);
+
+        Page<CurrentApplicantResponseDto> dtoPage = recruitingPostPage
+                .map(CurrentApplicantResponseDto::of);
+
+        return PagedResponse.of(dtoPage);
+    }
 
     @Transactional(readOnly = true)
     public CurrentApplicationDetailResponseDto getCurrentApplication(Long recruitingPostId, User user, Position position) {

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -40,7 +40,7 @@ public class MypageService {
         Page<Application> applicationPage = applicationService.getApplicationsByUser(user,pageable);
 
         Page<MyApplicationResponseDto> dtoPage = applicationPage
-                .map(application -> MyApplicationResponseDto.of(application.getRecruitingPost()));
+                .map(application -> MyApplicationResponseDto.of(application.getRecruitingPost(),application.getApplicationStatus().getDescription()));
 
         return PagedResponse.of(dtoPage);
     }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -35,7 +35,7 @@ public class MypageService {
 
     @Transactional(readOnly = true)
     public PagedResponse<MyApplicationResponseDto> getAllApplications(User user, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "recruitingPost.createdAt"));
 
         Page<Application> applicationPage = applicationService.getApplicationsByUser(user,pageable);
 

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -1,20 +1,27 @@
-package teamficial.teamficial_be.domain.user.service;
+package teamficial.teamficial_be.domain.myPage.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.application.dto.response.ApplicationResponseDto;
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.application.service.ApplicationService;
+import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicantResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.MyApplicationResponseDto;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostService;
-import teamficial.teamficial_be.domain.user.dto.CurrentApplicationResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicationDetailResponseDto;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 import teamficial.teamficial_be.global.enums.Position;
+import teamficial.teamficial_be.global.util.PagedResponse;
 
 import java.util.List;
 
@@ -27,12 +34,26 @@ public class MypageService {
     private final ApplicationService applicationService;
 
     @Transactional(readOnly = true)
-    public CurrentApplicationResponseDto getCurrentApplication(Long recruitingPostId, User user, Position position) {
+    public PagedResponse<MyApplicationResponseDto> getAllApplications(User user, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<Application> applicationPage = applicationService.getApplicationsByUser(user,pageable);
+
+        Page<MyApplicationResponseDto> dtoPage = applicationPage
+                .map(application -> MyApplicationResponseDto.of(application.getRecruitingPost()));
+
+        return PagedResponse.of(dtoPage);
+    }
+
+
+
+    @Transactional(readOnly = true)
+    public CurrentApplicationDetailResponseDto getCurrentApplication(Long recruitingPostId, User user, Position position) {
 
         RecruitingPost recruitingPost = recruitingPostService.getRecruitingPostById(recruitingPostId);
         recruitingPostService.validatePostOwner(user,recruitingPost);
 
-        List<Application> applications = applicationService.getApplications(recruitingPost);
+        List<Application> applications = applicationService.getApplicationsByRecruitingPost(recruitingPost);
 
         if (position != null) {
             applications = applications.stream()
@@ -40,7 +61,7 @@ public class MypageService {
                     .toList();
         }
 
-        return CurrentApplicationResponseDto.from(recruitingPost, applications);
+        return CurrentApplicationDetailResponseDto.from(recruitingPost, applications);
     }
 
     @Transactional
@@ -50,7 +71,7 @@ public class MypageService {
         recruitingPostService.validatePostOwner(user, recruitingPost);
 
         recruitingPost.closedRecruitingPost();
-        List<Application> applications = applicationService.getApplications(recruitingPost);
+        List<Application> applications = applicationService.getApplicationsByRecruitingPost(recruitingPost);
         applications.stream()
                 .filter(app -> app.getApplicationStatus() == ApplicationStatus.OPEN)
                 .forEach(app -> app.updateStatus(ApplicationStatus.CLOSED));
@@ -84,4 +105,5 @@ public class MypageService {
         application.updateStatus(ApplicationStatus.CONFIRMED);
         applicationService.saveApplication(application);
     }
+
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/entity/RecruitingPost.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/entity/RecruitingPost.java
@@ -72,6 +72,10 @@ public class RecruitingPost extends BaseEntity {
         this.status = RecruitingStatus.CLOSED;
     }
 
+    public int getTotalApplicants(){
+        return this.applications.size();
+    }
+
     public void update(RecruitingPostDTO.RecruitingPostModifyRequestDTO dto) {
         if (dto.getProgressWay() != null) this.progressWay = dto.getProgressWay();
         if (dto.getContactWay() != null) this.contactWay = dto.getContactWay();

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -17,5 +17,8 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
             "WHERE rp.id = :id")
     Optional<RecruitingPost> findByIdWithProfile(@Param("id") Long id);
 
+    @Query("SELECT rp FROM RecruitingPost rp " +
+            "LEFT JOIN FETCH rp.applications " +
+            "WHERE rp.profile.user.id = :userId")
     Page<RecruitingPost> findAllByProfile_User_Id(Long userId, Pageable pageable);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -1,5 +1,7 @@
 package teamficial.teamficial_be.domain.recruitingPost.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +16,6 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
             "JOIN FETCH rp.profile " +
             "WHERE rp.id = :id")
     Optional<RecruitingPost> findByIdWithProfile(@Param("id") Long id);
+
+    Page<RecruitingPost> findAllByProfile_User_Id(Long userId, Pageable pageable);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
@@ -1,6 +1,8 @@
 package teamficial.teamficial_be.domain.recruitingPost.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
@@ -141,5 +143,10 @@ public class RecruitingPostService {
         if (!user.getId().equals(writerId)) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
+    }
+
+    public Page<RecruitingPost> getAllRecruitingPostsByUser(Long userId,Pageable pageable) {
+
+        return recruitingPostRepository.findAllByProfile_User_Id(userId,pageable);
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/util/PagedResponse.java
+++ b/src/main/java/teamficial/teamficial_be/global/util/PagedResponse.java
@@ -1,0 +1,27 @@
+package teamficial.teamficial_be.global.util;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PagedResponse<T> {
+    private List<T> content;
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private boolean hasNext;
+
+    public static <T> PagedResponse<T> of(Page<T> page) {
+        return PagedResponse.<T>builder()
+                .content(page.getContent())
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #34 

## 📝작업 내용

> 커밋할 때 이슈 넘버 실수했습니다.. 34가 맞아요

- [x] 내가 지원한 팀 리스트 조회
- [x] 작성한 모집 글들의 지원자 현황 조회

### 스크린샷 (선택)
<img width="785" height="302" alt="image" src="https://github.com/user-attachments/assets/707fcafd-7cce-4175-b6f0-c6ad4879fe37" />
작성한 모집 글들의 지원자 현황 조회 테스트 결과
<img width="805" height="302" alt="image" src="https://github.com/user-attachments/assets/a89f5810-d547-405b-a4e5-d0468ebcfc1f" />
내가 지원한 팀 리스트 조회 테스트 결과

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지에서 지원 현황과 지원자 목록을 페이지네이션 기능과 함께 조회 가능
  * 채용공고별 지원자 상세 정보를 별도 화면에서 확인 가능

* **개선 사항**
  * 마이페이지 기능 재구조화로 더 나은 사용자 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->