### PR TITLE
[feat] 마이페이지 대시보드 api 구현 (#50)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -24,4 +24,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     @EntityGraph(attributePaths = {"user"})
     Page<Application> findAllByUserAndApplicationStatus(User user, Pageable pageable, ApplicationStatus status);
+
+    List<Application> findTop3ByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -92,4 +92,8 @@ public class ApplicationService {
     public void saveApplications(List<Application> applications) {
         applicationRepository.saveAll(applications);
     }
+
+    public List<Application> getTop3ByUser(User user) {
+        return applicationRepository.findTop3ByUserOrderByCreatedAtDesc(user);
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
@@ -9,6 +9,7 @@ import teamficial.teamficial_be.domain.application.dto.response.ApplicationRespo
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicantResponseDto;
 import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicationDetailResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.DashboardResponseDto;
 import teamficial.teamficial_be.domain.myPage.dto.response.MyApplicationResponseDto;
 import teamficial.teamficial_be.domain.myPage.service.MypageService;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
@@ -23,6 +24,13 @@ import teamficial.teamficial_be.global.util.PagedResponse;
 public class MypageController {
 
     private final MypageService mypageService;
+
+    @GetMapping("/my-page/dashboard")
+    @Operation(summary = "마이페이지 대쉬보드 조회", description = "GUI 4.1에 해당하는 내가 지원한 팀 3개, 작성한 모집 글 3개를 불러오는 API입니다.")
+    public ApiResponse<DashboardResponseDto> getDashboard(@AuthenticationPrincipal AuthDetails authDetails) {
+        DashboardResponseDto responseDto = mypageService.getUserDashBoard(authDetails.user());
+        return ApiResponse.onSuccess(responseDto);
+    }
 
     @GetMapping("/my-page/applications")
     @Operation(summary = "내가 지원한 팀 리스트 조회하기", description = "마이페이지에서 내가 지원한 팀들을 조회하는 API입니다.")

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/DashboardResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/DashboardResponseDto.java
@@ -1,0 +1,28 @@
+package teamficial.teamficial_be.domain.myPage.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import teamficial.teamficial_be.domain.application.entity.Application;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DashboardResponseDto {
+    List<MyApplicationResponseDto> myApplications;
+    List<CurrentApplicantResponseDto> myRecruitingPost;
+
+    public static DashboardResponseDto of(List<Application> applications, List<RecruitingPost> recruitingPosts) {
+        return DashboardResponseDto.builder()
+                .myApplications(applications.stream()
+                        .map(application -> MyApplicationResponseDto.of(application.getRecruitingPost(),application.getApplicationStatus().getDescription()))
+                        .toList()
+                )
+                .myRecruitingPost(recruitingPosts.stream()
+                        .map(recruitingPost-> CurrentApplicantResponseDto.of(recruitingPost, recruitingPost.getDDay()))
+                        .toList()
+                )
+                .build();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -13,6 +13,7 @@ import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.application.service.ApplicationService;
 import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicantResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.DashboardResponseDto;
 import teamficial.teamficial_be.domain.myPage.dto.response.MyApplicationResponseDto;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
@@ -123,4 +124,11 @@ public class MypageService {
         applicationService.saveApplication(application);
     }
 
+    @Transactional(readOnly = true)
+    public DashboardResponseDto getUserDashBoard(User user) {
+        List<RecruitingPost> recruitingPostList = recruitingPostService.getTop3ByUser(user);
+        List<Application> applicationList = applicationService.getTop3ByUser(user);
+
+        return DashboardResponseDto.of(applicationList,recruitingPostList);
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
+import teamficial.teamficial_be.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -27,4 +29,6 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
             "LEFT JOIN FETCH rp.applications " +
             "WHERE rp.profile.user.id = :userId AND rp.status = :recruitingStatus")
     Page<RecruitingPost> findAllByProfile_User_IdAndStatus(Long userId, Pageable pageable, RecruitingStatus recruitingStatus);
+
+    List<RecruitingPost> findTop3ByUserOrderByDeadlineAsc(User user);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
@@ -92,7 +92,6 @@ public class RecruitingPostService {
                 .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_RECRUITING_POST));
     }
 
-
     @Transactional
     public RecruitingPostDTO.RecruitingPostModifyResponseDTO updatePost(Long userId, Long postId, RecruitingPostDTO.RecruitingPostModifyRequestDTO dto) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
@@ -194,5 +193,7 @@ public class RecruitingPostService {
         });
     }
 
-
+    public List<RecruitingPost> getTop3ByUser(User user) {
+        return recruitingPostRepository.findTop3ByUserOrderByDeadlineAsc(user);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #50

## 📝작업 내용

> 피그마 GUI 4.1에 해당하는 마이페이지 대시보드 api를 구현했습니다.

<img width="794" height="303" alt="image" src="https://github.com/user-attachments/assets/b0687e65-5100-499a-9c05-dcb2ed7f220b" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신기능

* **대시보드 기능 추가**: 마이페이지에 새로운 대시보드가 추가되어, 사용자의 최근 지원 현황 3개와 진행 중인 모집 공고 3개를 한 번에 확인할 수 있습니다. 이를 통해 지원 상태와 모집 진행 상황을 쉽게 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->