### PR TITLE
[hotfix] 모집 글 단일 조회 시 profileId 추가

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDTO.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDTO.java
@@ -61,6 +61,7 @@ public class RecruitingPostDTO {
     @Builder
     public static class RecruitingPostsResponseDTO {
         private Long postId;                // 모집 글 Id
+        private Long profileId;
         private String userName;         // 작성자 이름
         private String profileImageUrl;     // profile image url
 
@@ -85,6 +86,7 @@ public class RecruitingPostDTO {
         public static RecruitingPostsResponseDTO from(RecruitingPost post, List<RecruitingDetail> recruitingDetails, long dDay) {
             return RecruitingPostsResponseDTO.builder()
                     .postId(post.getId())
+                    .profileId(post.getProfile().getId())
                     .userName(post.getProfile().getUserName())
                     .profileImageUrl(post.getProfile().getProfileImage())
                     .title(post.getTitle())
@@ -114,6 +116,7 @@ public class RecruitingPostDTO {
         @QueryProjection
         public RecruitingPostsResponseDTO(
                 Long postId,
+                Long profileId,
                 String userName,
                 String profileImageUrl,
                 ProgressWay progressWay,
@@ -127,6 +130,7 @@ public class RecruitingPostDTO {
                 LocalDateTime createdAt
         ) {
             this.postId = postId;
+            this.profileId = profileId;
             this.userName = userName;
             this.profileImageUrl = profileImageUrl;
             this.progressWay = progressWay;

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepositoryImpl.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepositoryImpl.java
@@ -41,6 +41,7 @@ public class RecruitingPostRepositoryImpl implements RecruitingPostRepositoryCus
         List<RecruitingPostDTO.RecruitingPostsResponseDTO> content = queryFactory
                 .select(new QRecruitingPostDTO_RecruitingPostsResponseDTO(
                         post.id,
+                        post.profile.id,
                         post.profile.userName,
                         post.profile.profileImage,
                         post.progressWay,


### PR DESCRIPTION
## 📝작업 내용

> 프론트 요청으로 모집 글 단일 조회api에 profileId를 추가했다


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채용 공고 응답에 프로필 ID 정보가 추가되었습니다. 각 채용 공고와 관련된 프로필을 더욱 명확하게 식별할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->