### PR TITLE
fix: 키워드 검증 로직 추가 (#61)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
@@ -58,11 +58,17 @@ public class TeamficialLogService {
             profile.getHeadKeywords().clear();
         }
 
+
         //대표키워드 설정
         if (requestDto.getKeywordIds() != null) {
             for (Long keywordId : requestDto.getKeywordIds()) {
 
                 Keyword keyword = keywordService.getKeywordById(keywordId);
+
+                if (!keyword.getUser().getId().equals(user.getId())) {
+                    throw new GeneralException(ErrorStatus.KEYWORD_FORBIDDEN);
+                }
+
                 keyword.updateHead();
                 keywordService.saveKeyword(keyword);
 

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -36,6 +36,8 @@ public enum ErrorStatus implements BaseErrorCode {
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),
 
+    //키워드 관련 응답
+    KEYWORD_FORBIDDEN(HttpStatus.FORBIDDEN,"KEYWORD4003","키워드 설정 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61

## 📝작업 내용

> 대표 키워드 설정 시 키워드 검증로직이 빠져서 추가했다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 키워드 설정 시 소유권 검증 기능이 추가되었습니다. 사용자는 자신이 소유한 키워드만 수정할 수 있으며, 소유하지 않은 키워드를 수정하려고 할 때는 권한 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->