### PR TITLE
[feat] 지원글 조회, 프로필 조회에 대표키워드 응답 필드 추가

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/dto/response/ApplicationResponseDto.java
@@ -16,7 +16,7 @@ public class ApplicationResponseDto {
         return ApplicationResponseDto.builder()
                 .applicationId(application.getId())
                 .content(application.getContent())
-                .profile(ProfileResponseDto.of(application.getProfile()))
+                .profile(ProfileResponseDto.of(application.getProfile(),application.getProfile().getHeadKeywords()))
                 .build();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
@@ -4,6 +4,7 @@ package teamficial.teamficial_be.domain.profile.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.profile.entity.ProfileLink;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
@@ -32,10 +33,12 @@ public class ProfileResponseDto {
     private List<String> links;
     @Schema(description = "연락 수단", example="오픈채팅방 링크")
     private String contactWay;
+    @Schema(description = "대표 키워드")
+    private List<String> headKeywords;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public static ProfileResponseDto of(Profile profile) {
+    public static ProfileResponseDto of(Profile profile, List<HeadKeyword> headKeywords) {
         List<String> linkList = profile.getProfileLinks().stream()
                 .map(ProfileLink::getLink)
                 .collect(Collectors.toList());
@@ -51,6 +54,10 @@ public class ProfileResponseDto {
                 .contactWay(profile.getContactWay())
                 .createdAt(profile.getCreatedAt())
                 .modifiedAt(profile.getUpdatedAt())
+                .headKeywords(headKeywords.stream()
+                        .map(HeadKeyword::getKeywordName)
+                        .toList()
+                )
                 .build();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package teamficial.teamficial_be.domain.profile.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import teamficial.teamficial_be.domain.keyword.service.HeadKeywordService;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
@@ -42,7 +43,7 @@ public class ProfileService {
         }
 
         profileRepository.save(profile);
-        return ProfileResponseDto.of(profile);
+        return ProfileResponseDto.of(profile,profile.getHeadKeywords());
     }
 
     @Transactional
@@ -58,13 +59,13 @@ public class ProfileService {
         }
 
         profileRepository.save(profile);
-        return ProfileResponseDto.of(profile);
+        return ProfileResponseDto.of(profile,profile.getHeadKeywords());
     }
 
     @Transactional(readOnly = true)
     public ProfileResponseDto getProfile(Long profileId){
         Profile profile = getProfileById(profileId);
-        return ProfileResponseDto.of(profile);
+        return ProfileResponseDto.of(profile,profile.getHeadKeywords());
     }
 
     @Transactional
@@ -126,7 +127,7 @@ public class ProfileService {
     public List<ProfileResponseDto> getProfileList(User user) {
         List<Profile> profiles = profileRepository.findAllByUser(user);
         return profiles.stream()
-                .map(profile -> ProfileResponseDto.of(profile))
+                .map(profile -> ProfileResponseDto.of(profile,profile.getHeadKeywords()))
                 .toList();
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDTO.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDTO.java
@@ -187,7 +187,7 @@ public class RecruitingPostDTO {
         public static RecruitingPostDetailResponseDTO from(RecruitingPost post, List<RecruitingDetail> recruitingDetails, long dDay) {
             return RecruitingPostDetailResponseDTO.builder()
                     .postId(post.getId())
-                    .profile(ProfileResponseDto.of(post.getProfile()))
+                    .profile(ProfileResponseDto.of(post.getProfile(),post.getProfile().getHeadKeywords()))
                     .title(post.getTitle())
                     .content(post.getContent())
                     .progressWay(post.getProgressWay())


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #26 ,#27

## 📝작업 내용

> 지원글 조회, 프로필 조회에 대표키워드 응답 필드를 추가했다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> profile.getHeadKeywords 부분 쿼리 최적화되어있는지 확인 부탁


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 응답에 주요 키워드(head keywords)가 포함되도록 추가했습니다.

* **개선 사항**
  * 프로필 조회·생성·수정 시 주요 키워드가 함께 반환됩니다.
  * 채용 공고·지원 정보 내 프로필에도 주요 키워드가 일관되게 포함되도록 통합했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->