### PR TITLE
feat : 게시글 마감 배치처리 구현(#76)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// Spring batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/teamficial/teamficial_be/TeamficialBeApplication.java
+++ b/src/main/java/teamficial/teamficial_be/TeamficialBeApplication.java
@@ -3,9 +3,11 @@ package teamficial.teamficial_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 public class TeamficialBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/teamficial/teamficial_be/batch/job/PostStatusUpdateJobConfig.java
+++ b/src/main/java/teamficial/teamficial_be/batch/job/PostStatusUpdateJobConfig.java
@@ -1,0 +1,24 @@
+package teamficial.teamficial_be.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import teamficial.teamficial_be.batch.step.PostStatusUpdateStepConfig;
+
+@Configuration
+@RequiredArgsConstructor
+public class PostStatusUpdateJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PostStatusUpdateStepConfig stepConfig;
+
+    @Bean
+    public Job postStatusUpdateJob() {
+        return new JobBuilder("postStatusUpdateJob", jobRepository)
+                .start(stepConfig.postStatusUpdateStep())
+                .build();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/teamficial/teamficial_be/batch/scheduler/BatchScheduler.java
@@ -1,0 +1,34 @@
+package teamficial.teamficial_be.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job postStatusUpdateJob; // job bean 주입
+
+//    @Scheduled(cron = "*/30 * * * * *") //테스트용
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    public void runPostStatusUpdateJob() {
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            jobLauncher.run(postStatusUpdateJob, params);
+            log.info("[Scheduler] 게시글 상태 업데이트 배치 실행 완료");
+        } catch (Exception e) {
+            log.error("[Scheduler] 게시글 상태 업데이트 배치 실행 실패", e);
+        }
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/batch/step/PostStatusUpdateStepConfig.java
+++ b/src/main/java/teamficial/teamficial_be/batch/step/PostStatusUpdateStepConfig.java
@@ -1,0 +1,26 @@
+package teamficial.teamficial_be.batch.step;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import teamficial.teamficial_be.batch.tasklet.PostStatusUpdateTasklet;
+
+@Configuration
+@RequiredArgsConstructor
+public class PostStatusUpdateStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final PostStatusUpdateTasklet postStatusUpdateTasklet;
+
+    @Bean
+    public Step postStatusUpdateStep() {
+        return new StepBuilder("postStatusUpdateStep", jobRepository)
+                .tasklet(postStatusUpdateTasklet, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/batch/tasklet/PostStatusUpdateTasklet.java
+++ b/src/main/java/teamficial/teamficial_be/batch/tasklet/PostStatusUpdateTasklet.java
@@ -1,0 +1,28 @@
+package teamficial.teamficial_be.batch.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import teamficial.teamficial_be.domain.recruitingPost.repository.RecruitingPostRepository;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostStatusUpdateTasklet implements Tasklet {
+
+    private final RecruitingPostRepository recruitingPostRepository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        LocalDate today = LocalDate.now();
+        int updatedCount = recruitingPostRepository.updateStatusToClosed(today);
+        log.info("[Batch] 마감일이 지난 게시글 {}건 CLOSED 처리 완료", updatedCount);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,7 @@ import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
 import teamficial.teamficial_be.domain.user.entity.User;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,4 +36,8 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
             "ORDER BY rp.deadline ASC " +
             "LIMIT 3")
     List<RecruitingPost> findTop3ByUserOrderByDeadlineAsc(@Param("user") User user);
+
+    @Modifying
+    @Query("UPDATE RecruitingPost p SET p.status = 'CLOSED' WHERE p.deadline < :today AND p.status <> 'CLOSED'")
+    int updateStatusToClosed(@Param("today") LocalDate today);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #76 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [ ] tasklet 방식 기반 게시글 마감 배치처리 구현
- [ ] 오전 00시에 게시글 배치처리 (추후 멀티모듈, chunk기반 방식으로 확장 예정)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 구인공고 자동 상태 관리 시스템이 추가되었습니다. 매일 자정에 마감 기한이 지난 구인공고를 자동으로 마감 상태로 업데이트합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->