### PR TITLE
[refactor] 지원자 수 집계 쿼리 성능 개선

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -32,4 +32,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             "ORDER BY ap.createdAt DESC " +
             "LIMIT 3")
     List<Application> findTop3ByUserOrderByCreatedAtDesc(User user);
+
+    @Query("SELECT COUNT(a) FROM Application a WHERE a.recruitingPost.id = :postId")
+    int countAllByRecruitingPost(RecruitingPost recruitingPost);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
@@ -34,4 +35,10 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findTop3ByUserOrderByCreatedAtDesc(User user);
 
     int countAllByRecruitingPost(RecruitingPost recruitingPost);
+
+    @Query("SELECT a.recruitingPost.id, COUNT(a) " +
+            "FROM Application a " +
+            "WHERE a.recruitingPost.id IN :postIds " +
+            "GROUP BY a.recruitingPost.id")
+    List<Object[]> countByRecruitingPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -33,6 +33,5 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             "LIMIT 3")
     List<Application> findTop3ByUserOrderByCreatedAtDesc(User user);
 
-    @Query("SELECT COUNT(a) FROM Application a WHERE a.recruitingPost.id = :postId")
     int countAllByRecruitingPost(RecruitingPost recruitingPost);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -1,9 +1,11 @@
 package teamficial.teamficial_be.domain.application.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.application.dto.ApplicationDTO;
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
@@ -17,9 +19,11 @@ import teamficial.teamficial_be.domain.user.repository.UserRepository;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 import teamficial.teamficial_be.global.apiPayload.exception.handler.NotFoundHandler;
+import teamficial.teamficial_be.global.redis.RedisService;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApplicationService {
@@ -27,7 +31,9 @@ public class ApplicationService {
     private final ProfileRepository profileRepository;
     private final RecruitingPostRepository recruitingPostRepository;
     private final ApplicationRepository applicationRepository;
+    private final RedisService redisService;
 
+    @Transactional
     public ApplicationDTO.ApplicationResponseDTO createApplication(Long userId, ApplicationDTO.ApplicationRequestDTO req) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
@@ -60,6 +66,7 @@ public class ApplicationService {
                 .build();
 
         Application saved = applicationRepository.save(application);
+        applicantIncrement(recruitingPost);
 
         return ApplicationDTO.ApplicationResponseDTO.builder()
                 .applicationId(saved.getId())
@@ -101,5 +108,26 @@ public class ApplicationService {
 
     public List<Application> getTop3ByUser(User user) {
         return applicationRepository.findTop3ByUserOrderByCreatedAtDesc(user);
+    }
+
+    public int getApplicantCount(RecruitingPost recruitingPost) {
+        return applicationRepository.countAllByRecruitingPost(recruitingPost);
+    }
+
+    @Transactional
+    public void applicantIncrement(RecruitingPost recruitingPost) {
+        String key = redisService.applicationKey(recruitingPost.getId());
+        try {
+            // 존재하는 경우 increment
+            if (redisService.checkExistsValue(key)) {
+                redisService.incrementValue(key, 1);
+            } else {
+                // 키 없으면 저장
+                long count = applicationRepository.countAllByRecruitingPost(recruitingPost);
+                redisService.setValue(key, String.valueOf(count + 1), 0L);
+            }
+        } catch (Exception e) {
+            log.warn("Redis increment error key={}, postId={}", key, recruitingPost.getId(), e);
+        }
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -123,7 +123,7 @@ public class ApplicationService {
                 redisService.incrementValue(key, 1);
             } else {
                 // 키 없으면 저장
-                long count = applicationRepository.countAllByRecruitingPost(recruitingPost);
+                int count = applicationRepository.countAllByRecruitingPost(recruitingPost);
                 redisService.setValue(key, String.valueOf(count + 1), 0L);
             }
         } catch (Exception e) {

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -21,7 +21,10 @@ import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 import teamficial.teamficial_be.global.apiPayload.exception.handler.NotFoundHandler;
 import teamficial.teamficial_be.global.redis.RedisService;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -129,5 +132,20 @@ public class ApplicationService {
         } catch (Exception e) {
             log.warn("Redis increment error key={}, postId={}", key, recruitingPost.getId(), e);
         }
+    }
+
+    public Map<Long, Integer> getApplicantCountBatch(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Object[]> results = applicationRepository.countByRecruitingPostIds(postIds);
+
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0], //postId
+                        row -> ((Long) row[1]).intValue() //count
+                ));
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -124,7 +124,7 @@ public class ApplicationService {
             } else {
                 // 키 없으면 저장
                 int count = applicationRepository.countAllByRecruitingPost(recruitingPost);
-                redisService.setValue(key, String.valueOf(count + 1), 0L);
+                redisService.setValue(key, String.valueOf(count), 0L);
             }
         } catch (Exception e) {
             log.warn("Redis increment error key={}, postId={}", key, recruitingPost.getId(), e);

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -113,10 +113,6 @@ public class ApplicationService {
         return applicationRepository.findTop3ByUserOrderByCreatedAtDesc(user);
     }
 
-    public int getApplicantCount(RecruitingPost recruitingPost) {
-        return applicationRepository.countAllByRecruitingPost(recruitingPost);
-    }
-
     @Transactional
     public void applicantIncrement(RecruitingPost recruitingPost) {
         String key = redisService.applicationKey(recruitingPost.getId());
@@ -141,11 +137,13 @@ public class ApplicationService {
 
         List<Object[]> results = applicationRepository.countByRecruitingPostIds(postIds);
 
-
-        return results.stream()
+        Map<Long,Integer> counts = results.stream()
                 .collect(Collectors.toMap(
                         row -> (Long) row[0], //postId
                         row -> ((Long) row[1]).intValue() //count
                 ));
+
+        postIds.forEach(postId -> {counts.putIfAbsent(postId, 0);});
+        return counts;
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicantResponseDto.java
@@ -30,7 +30,7 @@ public class CurrentApplicantResponseDto {
     private LocalDateTime createdAt;
     private long dDay;
 
-    public static CurrentApplicantResponseDto of(RecruitingPost recruitingPost,long dDay) {
+    public static CurrentApplicantResponseDto of(RecruitingPost recruitingPost,long dDay,int totalApplicants) {
         List<String> tags = recruitingPost.getRecruitingDetails().stream()
                 .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
                 .toList();
@@ -40,7 +40,7 @@ public class CurrentApplicantResponseDto {
                 .title(recruitingPost.getTitle())
                 .profileImage(recruitingPost.getProfile().getProfileImage())
                 .writerName(recruitingPost.getProfile().getUserName())
-                .totalApplicants(recruitingPost.getTotalApplicants())
+                .totalApplicants(totalApplicants)
                 .tags(tags)
                 .deadline(recruitingPost.getDeadline())
                 .createdAt(recruitingPost.getCreatedAt())

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/DashboardResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/DashboardResponseDto.java
@@ -13,16 +13,4 @@ public class DashboardResponseDto {
     List<MyApplicationResponseDto> myApplications;
     List<CurrentApplicantResponseDto> myRecruitingPost;
 
-    public static DashboardResponseDto of(List<Application> applications, List<RecruitingPost> recruitingPosts) {
-        return DashboardResponseDto.builder()
-                .myApplications(applications.stream()
-                        .map(application -> MyApplicationResponseDto.of(application.getRecruitingPost(),application.getApplicationStatus().getDescription()))
-                        .toList()
-                )
-                .myRecruitingPost(recruitingPosts.stream()
-                        .map(recruitingPost-> CurrentApplicantResponseDto.of(recruitingPost, recruitingPost.getDDay()))
-                        .toList()
-                )
-                .build();
-    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -26,7 +26,10 @@ import teamficial.teamficial_be.global.enums.Position;
 import teamficial.teamficial_be.global.redis.RedisService;
 import teamficial.teamficial_be.global.util.PagedResponse;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -49,19 +52,69 @@ public class MypageService {
         return PagedResponse.of(dtoPage);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public PagedResponse<CurrentApplicantResponseDto> getAllCurrentApplication(User user, int page, int size, RecruitingStatus recruitingStatus) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "deadline"));
 
         Page<RecruitingPost> recruitingPostPage = recruitingPostService.getAllRecruitingPostsByUserAndStatus(user,pageable,recruitingStatus);
 
+        List<Long> postIds = recruitingPostPage.stream()
+                .map(RecruitingPost::getId)
+                .toList();
+
+        Map<Long,Integer> applicantCountMap = getApplicantCountsBatch(postIds);
+
         Page<CurrentApplicantResponseDto> dtoPage = recruitingPostPage.map(recruitingPost -> {
             long dDay = recruitingPost.getDDay();
-            int totalApplicants = getApplicantCount(recruitingPost);
+            //int totalApplicants = getApplicantCount(recruitingPost);
+            int totalApplicants = applicantCountMap.get(recruitingPost.getId());
             return CurrentApplicantResponseDto.of(recruitingPost,dDay,totalApplicants);
         });
 
         return PagedResponse.of(dtoPage);
+    }
+
+    private Map<Long, Integer> getApplicantCountsBatch(List<Long> postIds) {
+        List<String> keys = postIds.stream()
+                .map(redisService::applicationKey)
+                .toList();
+
+        List<String> cachedValues = redisService.getValues(keys);
+
+        Map<Long,Integer> resultMap = new HashMap<>();
+        List<Long> missIds = new ArrayList<>();
+
+        for (int i=0; i < postIds.size(); i++) {
+            Long postId = postIds.get(i);
+            String key = keys.get(i);
+            String value = cachedValues.get(i);
+
+            if (value != null && !value.isEmpty()) {
+                resultMap.put(postId, Integer.parseInt(value));
+                log.debug("캐시 히트 key={}, value={}, postId={}", key, value, postId);
+            } else {
+                log.debug("캐시 미스 key={}, postId={}", key, postId);
+                missIds.add(postId);
+            }
+        }
+
+        if (!missIds.isEmpty()) {
+            log.debug("DB 조회 대상 모집글들: {}", missIds);
+            Map<Long, Integer> dbCounts = applicationService.getApplicantCountBatch(missIds);
+
+            Map<String, String> cacheData = new HashMap<>();
+            dbCounts.forEach((postId,count) -> {
+                resultMap.put(postId, count);
+                cacheData.put(redisService.applicationKey(postId), String.valueOf(count));
+            });
+
+            if (!cacheData.isEmpty()) {
+                redisService.setValues(cacheData);
+                log.debug("캐시 일괄 저장 완료 keys={}", cacheData.keySet());
+            }
+        }
+
+        return resultMap;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -185,10 +185,16 @@ public class MypageService {
         List<RecruitingPost> recruitingPostList = recruitingPostService.getTop3ByUser(user);
         List<Application> applicationList = applicationService.getTop3ByUser(user);
 
+        List<Long> postIds = recruitingPostList.stream()
+                .map(RecruitingPost::getId)
+                .toList();
+
+        Map<Long,Integer> applicantCountMap = getApplicantCountsBatch(postIds);
+
         List<CurrentApplicantResponseDto> recruitingDtos = recruitingPostList.stream()
                 .map(recruitingPost -> {
                     long dDay = recruitingPost.getDDay();
-                    int totalApplicants = getApplicantCount(recruitingPost);
+                    int totalApplicants = applicantCountMap.get(recruitingPost.getId());
                     return CurrentApplicantResponseDto.of(recruitingPost, dDay, totalApplicants);
                 })
                 .toList();
@@ -203,20 +209,6 @@ public class MypageService {
                 .myRecruitingPost(recruitingDtos)
                 .myApplications(applicationDtos)
                 .build();
-    }
-
-    @Transactional
-    public int getApplicantCount(RecruitingPost recruitingPost){
-        String key = redisService.applicationKey(recruitingPost.getId());
-        String value = redisService.getValue(key);
-
-        if (value.isEmpty()){
-            int count = applicationService.getApplicantCount(recruitingPost);
-            value = String.valueOf(count);
-            redisService.setValue(key,String.valueOf(count),0L);
-        }
-
-        return Integer.parseInt(value);
     }
 
 }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -23,6 +23,7 @@ import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 import teamficial.teamficial_be.global.enums.Position;
+import teamficial.teamficial_be.global.redis.RedisService;
 import teamficial.teamficial_be.global.util.PagedResponse;
 
 import java.util.List;
@@ -34,6 +35,7 @@ public class MypageService {
 
     private final RecruitingPostService recruitingPostService;
     private final ApplicationService applicationService;
+    private final RedisService redisService;
 
     @Transactional(readOnly = true)
     public PagedResponse<MyApplicationResponseDto> getAllApplications(User user, int page, int size,ApplicationStatus applicationStatus) {
@@ -55,7 +57,8 @@ public class MypageService {
 
         Page<CurrentApplicantResponseDto> dtoPage = recruitingPostPage.map(recruitingPost -> {
             long dDay = recruitingPost.getDDay();
-            return CurrentApplicantResponseDto.of(recruitingPost,dDay);
+            int totalApplicants = getApplicantCount(recruitingPost);
+            return CurrentApplicantResponseDto.of(recruitingPost,dDay,totalApplicants);
         });
 
         return PagedResponse.of(dtoPage);
@@ -129,6 +132,38 @@ public class MypageService {
         List<RecruitingPost> recruitingPostList = recruitingPostService.getTop3ByUser(user);
         List<Application> applicationList = applicationService.getTop3ByUser(user);
 
-        return DashboardResponseDto.of(applicationList,recruitingPostList);
+        List<CurrentApplicantResponseDto> recruitingDtos = recruitingPostList.stream()
+                .map(recruitingPost -> {
+                    long dDay = recruitingPost.getDDay();
+                    int totalApplicants = getApplicantCount(recruitingPost);
+                    return CurrentApplicantResponseDto.of(recruitingPost, dDay, totalApplicants);
+                })
+                .toList();
+
+        List<MyApplicationResponseDto> applicationDtos = applicationList.stream()
+                .map(app -> MyApplicationResponseDto.of(
+                        app.getRecruitingPost(),
+                        app.getApplicationStatus().getDescription()))
+                .toList();
+
+        return DashboardResponseDto.builder()
+                .myRecruitingPost(recruitingDtos)
+                .myApplications(applicationDtos)
+                .build();
     }
+
+    @Transactional
+    public int getApplicantCount(RecruitingPost recruitingPost){
+        String key = redisService.applicationKey(recruitingPost.getId());
+        String value = redisService.getValue(key);
+
+        if (value.isEmpty()){
+            int count = applicationService.getApplicantCount(recruitingPost);
+            value = String.valueOf(count);
+            redisService.setValue(key,String.valueOf(count),0L);
+        }
+
+        return Integer.parseInt(value);
+    }
+
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/entity/RecruitingPost.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/entity/RecruitingPost.java
@@ -78,10 +78,6 @@ public class RecruitingPost extends BaseEntity {
         this.status = RecruitingStatus.CLOSED;
     }
 
-    public int getTotalApplicants(){
-        return this.applications.size();
-    }
-
     public void update(RecruitingPostDTO.RecruitingPostModifyRequestDTO dto) {
         if (dto.getProgressWay() != null) this.progressWay = dto.getProgressWay();
         if (dto.getContactWay() != null) this.contactWay = dto.getContactWay();

--- a/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
@@ -28,15 +28,13 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
 
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-
-        return redisTemplate;
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setDefaultSerializer(new StringRedisSerializer());
+        return template;
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/redis/RedisService.java
+++ b/src/main/java/teamficial/teamficial_be/global/redis/RedisService.java
@@ -16,6 +16,8 @@ import java.time.Duration;
 public class RedisService {
     private final RedisTemplate<String, Object> redisTemplate;
 
+    private static final String APPLICANT_COUNT_KEY_PREFIX = "recruit:post:";
+
     public void setValue(String key, String value, long ttlMillis) {
         try {
             ValueOperations<String, Object> values = redisTemplate.opsForValue();
@@ -52,5 +54,19 @@ public class RedisService {
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus.REDIS_ERROR);
         }
+    }
+
+    public void incrementValue(String key, long delta) {
+        try {
+            ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+            ops.increment(key, delta);
+        } catch (Exception e) {
+            log.warn("Redis 지원자 수 increment 오류 — key: {}, delta: {}, 예외: {}", key, delta, e.toString(), e);
+            throw new GeneralException(ErrorStatus.REDIS_ERROR);
+        }
+    }
+
+    public String applicationKey(Long postId) {
+        return APPLICANT_COUNT_KEY_PREFIX + postId + ":applicantCount";
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/redis/RedisService.java
+++ b/src/main/java/teamficial/teamficial_be/global/redis/RedisService.java
@@ -9,19 +9,28 @@ import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisService {
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
 
     private static final String APPLICANT_COUNT_KEY_PREFIX = "recruit:post:";
 
     public void setValue(String key, String value, long ttlMillis) {
         try {
-            ValueOperations<String, Object> values = redisTemplate.opsForValue();
-            values.set(key, value, Duration.ofMillis(ttlMillis));
+            if (ttlMillis > 0) {
+                ValueOperations<String, String> values = redisTemplate.opsForValue();
+                values.set(key, value, Duration.ofMillis(ttlMillis));
+            } else {
+                ValueOperations<String, String> values = redisTemplate.opsForValue();
+                values.set(key, value);
+            }
+
         } catch (Exception e) {
             log.error("Redis set 오류 — key: {}, ttl: {}, 예외: {}", key, ttlMillis, e.toString(), e);
             throw new GeneralException(ErrorStatus.REDIS_ERROR);
@@ -30,7 +39,7 @@ public class RedisService {
 
     public String getValue(String key) {
         try {
-            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            ValueOperations<String, String> values = redisTemplate.opsForValue();
             if (values.get(key) == null) {
                 return "";
             }
@@ -58,7 +67,7 @@ public class RedisService {
 
     public void incrementValue(String key, long delta) {
         try {
-            ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+            ValueOperations<String, String> ops = redisTemplate.opsForValue();
             ops.increment(key, delta);
         } catch (Exception e) {
             log.warn("Redis 지원자 수 increment 오류 — key: {}, delta: {}, 예외: {}", key, delta, e.toString(), e);
@@ -68,5 +77,20 @@ public class RedisService {
 
     public String applicationKey(Long postId) {
         return APPLICANT_COUNT_KEY_PREFIX + postId + ":applicantCount";
+    }
+
+    public List<String> getValues(List<String> keys) {
+        if (keys == null || keys.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return redisTemplate.opsForValue().multiGet(keys);
+    }
+
+    public void setValues(Map<String, String> cacheData) {
+        if (cacheData.isEmpty()) {
+            return;
+        }
+        redisTemplate.opsForValue().multiSet(cacheData);
+
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #80 

## 📝작업 내용

이전에는 지원자 현황 조회할 때마다 매번 db에 접근하여 전체 로딩을 했는데, 캐시 조회로 전환하여 메모리 사용량 및 DB 부하를 감소시켰다

또한 단일 카운트 쿼리로 집계하여 불필요한 컬렉션 로딩을 없앴다

## 💬리뷰 요구사항& 추후 생각해봐야할 것

> 단일 count 쿼리도 모집글 수나 지원자 수 이후에 많아지면 비용이 생길텐데, 이 때 어떻게 처리할지 생각하기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 레디스 기반 실시간 지원자 수 카운팅 및 지원 시 즉시 증가 반영 추가

* **개선 사항**
  * 대시보드·마이페이지에서 지원자 수 조회 성능 향상(일괄 조회·캐시 활용)
  * 캐시 미존재 시 정확한 총합 보정으로 일관된 수치 표시 보장

* **변경**
  * 지원자 수 제공 방식이 캐시 기반 배치 조회로 전환되어 최신성·응답성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->