### PR TITLE
[fix] 프로필 삭제 로직 soft delete로 변경

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
+import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.user.entity.User;
 
@@ -41,4 +42,9 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             "WHERE a.recruitingPost.id IN :postIds " +
             "GROUP BY a.recruitingPost.id")
     List<Object[]> countByRecruitingPostIds(@Param("postIds") List<Long> postIds);
+
+    @Query("SELECT ap FROM Application ap " +
+            "JOIN FETCH ap.profile p " +
+            "WHERE p = :profile")
+    List<Application> findAllByProfile(Profile profile);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -146,4 +146,9 @@ public class ApplicationService {
         postIds.forEach(postId -> {counts.putIfAbsent(postId, 0);});
         return counts;
     }
+
+    public List<Application> getApplicationsByProfile(Profile profile) {
+        return applicationRepository.findAllByProfile(profile);
+    }
+
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -44,6 +44,10 @@ public class ApplicationService {
         Profile profile = profileRepository.findById(req.getProfileId())
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
 
+        if (profile.isDeleted()){
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE);
+        }
+
         if (!profile.getUser().getId().equals(userId)) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
@@ -53,6 +53,12 @@ public class Profile extends BaseEntity {
     @Column(name = "contact_way", length = 255)
     private String contactWay;
 
+    private boolean isDeleted = false;
+
+    public void deleteProfile(){
+        this.isDeleted = true;
+    }
+
     public void update(ProfileRequestDto dto) {
         this.profileName = dto.getProfileName();
         this.workingTime = dto.getWorkingTime();

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.user.entity.User;
@@ -15,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@SQLDelete(sql = "UPDATE profile SET is_deleted = 1 WHERE profile_id = ?")
+@Where(clause = "is_deleted = 0")
 @Getter
 @Builder
 @AllArgsConstructor
@@ -53,11 +57,8 @@ public class Profile extends BaseEntity {
     @Column(name = "contact_way", length = 255)
     private String contactWay;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "tinyint(1) default 0")
     private boolean isDeleted = false;
-
-    public void deleteProfile(){
-        this.isDeleted = true;
-    }
 
     public void update(ProfileRequestDto dto) {
         this.profileName = dto.getProfileName();

--- a/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/entity/Profile.java
@@ -11,14 +11,11 @@ import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.entity.BaseEntity;
-import teamficial.teamficial_be.global.enums.Position;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@SQLDelete(sql = "UPDATE profile SET is_deleted = 1 WHERE profile_id = ?")
-@Where(clause = "is_deleted = 0")
 @Getter
 @Builder
 @AllArgsConstructor
@@ -59,6 +56,10 @@ public class Profile extends BaseEntity {
 
     @Column(name = "is_deleted", nullable = false, columnDefinition = "tinyint(1) default 0")
     private boolean isDeleted = false;
+
+    public void deleteProfile() {
+        this.isDeleted = true;
+    }
 
     public void update(ProfileRequestDto dto) {
         this.profileName = dto.getProfileName();

--- a/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
-    @Query("SELECT p FROM Profile p " +
-            "WHERE p.user = :user")
-    List<Profile> findAllByUser(@Param("user") User user);
+
+    List<Profile> findAllByUserAndIsDeletedFalse(User user);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -71,7 +71,6 @@ public class ProfileService {
     @Transactional
     public void deleteProfile(User user,Long profileId) {
 
-
         Profile profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_PROFILE));
 
@@ -83,7 +82,8 @@ public class ProfileService {
             preSignedUrlService.deleteByKey(objectKey);
         }
 
-        profileRepository.delete(profile);
+        profile.deleteProfile();
+        profileRepository.save(profile);
     }
 
     @Transactional

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -3,6 +3,9 @@ package teamficial.teamficial_be.domain.profile.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import teamficial.teamficial_be.domain.application.entity.Application;
+import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
+import teamficial.teamficial_be.domain.application.service.ApplicationService;
 import teamficial.teamficial_be.domain.keyword.service.HeadKeywordService;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
@@ -19,6 +22,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
+    private final ApplicationService applicationService;
     private final ProfileRepository profileRepository;
     private final PreSignedUrlService preSignedUrlService;
 
@@ -76,13 +80,32 @@ public class ProfileService {
 
         validateUserProfile(user, profile);
 
-        String image = profile.getProfileImage();
-        if (image != null && !image.isBlank()) {
-            String objectKey = preSignedUrlService.extractKeyFromUrl(image);
-            preSignedUrlService.deleteByKey(objectKey);
-        }
-        profileRepository.delete(profile);
+        // 이 프로필을 사용한 Application 존재하는지 확인
+        List<Application> applications = applicationService.getApplicationsByProfile(profile);
+        if (!applications.isEmpty()) {
+            // 존재한다면, applicationStatus 확인
+            boolean hasMatchable = applications.stream()
+                    .anyMatch(app -> app.getApplicationStatus() == ApplicationStatus.MATCHED
+                            || app.getApplicationStatus() == ApplicationStatus.MATCH_FAILED);
 
+            if (hasMatchable) {
+                // soft-delete 처리
+                profile.deleteProfile();
+                profileRepository.save(profile);
+            } else {
+                // 매칭 대기 상태라면 삭제 금지
+                throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING);
+            }
+        } else {
+            // 3) Application이 아예 없다면 물리 삭제 가능
+            // 이미지 삭제 로직 수행
+            String image = profile.getProfileImage();
+            if (image != null && !image.isBlank()) {
+                String objectKey = preSignedUrlService.extractKeyFromUrl(image);
+                preSignedUrlService.deleteByKey(objectKey);
+            }
+            profileRepository.delete(profile);
+        }
     }
 
     @Transactional
@@ -124,7 +147,7 @@ public class ProfileService {
 
     @Transactional(readOnly = true)
     public List<ProfileResponseDto> getProfileList(User user) {
-        List<Profile> profiles = profileRepository.findAllByUser(user);
+        List<Profile> profiles = profileRepository.findAllByUserAndIsDeletedFalse(user);
         return profiles.stream()
                 .map(profile -> ProfileResponseDto.of(profile,profile.getHeadKeywords()))
                 .toList();

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -81,9 +81,8 @@ public class ProfileService {
             String objectKey = preSignedUrlService.extractKeyFromUrl(image);
             preSignedUrlService.deleteByKey(objectKey);
         }
+        profileRepository.delete(profile);
 
-        profile.deleteProfile();
-        profileRepository.save(profile);
     }
 
     @Transactional

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     FAILED_IMAGE_DELETE(HttpStatus.BAD_REQUEST,"PROFILE4001","이미지 삭제를 실패했습니다."),
     ALREADY_DELETED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE4002" , "프로필 사진이 이미 삭제된 상태입니다."),
     PROFILE_FORBIDDEN(HttpStatus.FORBIDDEN,"PROFILE4003","프로필 수정 권한이 없습니다."),
+    CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 지원중인 공고가 있어, 삭제가 불가능합니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #82 

## 📝작업 내용

> 기획에 맞게 프로필 삭제 로직을 수정하였다.

1. 해당 프로필로 지원한 결과가 아직 안 나온 상태에서 삭제할 경우 
    -> 삭제 못하게 제한
2. 해당 프로필로 지원한 결과가 나온 상태에서 삭제할 경우 
    -> 추후에 연락방법이나, 다른 정보들을 확인할 수 있게 soft delete
3. 지원하지 않은 상태에서 프로필을 삭제할 경우
    -> hard delete

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 소프트 삭제 추가: 매칭 이력 보존을 위해 프로필을 보관 상태로 전환합니다.
  * 프로필별 지원서 조회 지원: 특정 프로필로 등록한 지원서를 확인할 수 있습니다.

* **Bug Fixes / Behaviors**
  * 진행 중인(대기) 지원서가 있으면 프로필 삭제 차단 및 안내 표시.
  * 프로필 목록에서 삭제된(보관된) 프로필 자동 제외.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->