### PR TITLE
[fix] 프로필 삭제 로직 수정

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/entity/Application.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/entity/Application.java
@@ -40,6 +40,7 @@ public class Application extends BaseEntity {
     private Position position;
 
     @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private ApplicationStatus applicationStatus;
 
     @Lob

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -52,7 +52,7 @@ public class MypageService {
         return PagedResponse.of(dtoPage);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public PagedResponse<CurrentApplicantResponseDto> getAllCurrentApplication(User user, int page, int size, RecruitingStatus recruitingStatus) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "deadline"));
 
@@ -121,6 +121,7 @@ public class MypageService {
     public CurrentApplicationDetailResponseDto getCurrentApplication(Long recruitingPostId, User user, Position position) {
 
         RecruitingPost recruitingPost = recruitingPostService.getRecruitingPostById(recruitingPostId);
+        log.info("모집 글 id: " + recruitingPost.getId());
         recruitingPostService.validatePostOwner(user,recruitingPost);
 
         long dDay = recruitingPost.getDDay();

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileResponseDto.java
@@ -35,6 +35,8 @@ public class ProfileResponseDto {
     private String contactWay;
     @Schema(description = "대표 키워드")
     private List<String> headKeywords;
+
+    private boolean isDeleted;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -55,6 +57,7 @@ public class ProfileResponseDto {
                 .workingTime(workingTimeDesc)
                 .links(linkList)
                 .contactWay(profile.getContactWay())
+                .isDeleted(profile.isDeleted())
                 .createdAt(profile.getCreatedAt())
                 .modifiedAt(profile.getUpdatedAt())
                 .headKeywords(headKeywords.stream()

--- a/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
@@ -13,4 +13,7 @@ import java.util.List;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     List<Profile> findAllByUserAndIsDeletedFalse(User user);
+
+    @Query("select p from Profile  p where p.user = :user and p.isDeleted = false")
+    int countByUser(User user);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
@@ -14,6 +14,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     List<Profile> findAllByUserAndIsDeletedFalse(User user);
 
-    @Query("select p from Profile  p where p.user = :user and p.isDeleted = false")
+    @Query("select count(p) from Profile  p where p.user = :user and p.isDeleted = false")
     int countByUser(User user);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -43,6 +43,12 @@ public class ProfileService {
             workingTime = requestDto.getWorkingTime();
         }
 
+        int count = profileRepository.countByUser(user);
+
+        if (count > 3) {
+            throw new GeneralException(ErrorStatus.CANNOT_COUNT_OVER_3);
+        }
+
         Profile profile = Profile.builder()
                 .user(user)
                 .userName(user.getName())

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -99,37 +99,65 @@ public class ProfileService {
         // 이 프로필을 사용한 Application 존재하는지 확인
         List<Application> applications = applicationService.getApplicationsByProfile(profile);
         List<RecruitingPost> recruitingPosts  = recruitingPostService.getRecruitingPostsByProfile(profile);
-        if (!applications.isEmpty() || !recruitingPosts.isEmpty()) {
-            // 존재한다면, applicationStatus 확인
-            boolean applicationHasMatchable = applications.stream()
-                    .anyMatch(app -> app.getApplicationStatus() == ApplicationStatus.MATCHED
-                            || app.getApplicationStatus() == ApplicationStatus.MATCH_FAILED);
 
-            boolean recruitingPostHasMatchable = recruitingPosts.stream()
-                    .anyMatch(recruitingPost -> recruitingPost.getStatus()== RecruitingStatus.CLOSED);
+        boolean hasAnyApplication = !applications.isEmpty();
+        boolean hasMatchingApplication = applications.stream()
+                .anyMatch(a -> a.getApplicationStatus() == ApplicationStatus.MATCHING);
+        boolean hasMatchedOrFailedApplication = applications.stream()
+                .anyMatch(a -> a.getApplicationStatus() == ApplicationStatus.MATCHED
+                        || a.getApplicationStatus() == ApplicationStatus.MATCH_FAILED);
 
-            if (applicationHasMatchable && recruitingPostHasMatchable) {
-                // soft-delete 처리
-                profile.deleteProfile();
-                profileRepository.save(profile);
-            } else if (!applicationHasMatchable) {
-                // 매칭 대기 상태라면 삭제 금지
+        boolean hasAnyPost = !recruitingPosts.isEmpty();
+        boolean hasOpenPost = recruitingPosts.stream()
+                .anyMatch(p -> p.getStatus() == RecruitingStatus.OPEN);
+        boolean hasClosedPost = recruitingPosts.stream()
+                .anyMatch(p -> p.getStatus() == RecruitingStatus.CLOSED);
+
+        boolean softDeleteAboutApp = false;
+        //지원관련 필터링
+        if (hasAnyApplication) {
+            if (hasMatchingApplication) {
                 throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING);
-            } else if (!recruitingPostHasMatchable) {
-                throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN);
+            } else {
+                softDeleteAboutApp = true;
             }
         } else {
-            // 3) Application이 아예 없다면 물리 삭제 가능
-            // 이미지 삭제 로직 수행
+            softDeleteAboutApp = true;
+        }
+
+        boolean softDeleteAboutRp = false;
+        //모집글 관련 필터링
+        if (hasAnyPost) {
+            if (hasOpenPost) {
+                throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN);
+            }
+            else {
+                softDeleteAboutRp = true;
+            }
+        } else {
+            softDeleteAboutRp = true;
+        }
+
+        // 소프트 삭제
+        if (softDeleteAboutRp && softDeleteAboutApp) {
+            profile.deleteProfile();
+            profileRepository.save(profile);
+            return;
+        }
+
+        // 하드 삭제
+        if (!hasAnyApplication && !hasAnyPost) {
             String image = profile.getProfileImage();
             if (image != null && !image.isBlank()) {
                 String objectKey = preSignedUrlService.extractKeyFromUrl(image);
                 preSignedUrlService.deleteByKey(objectKey);
             }
             profileRepository.delete(profile);
+            return;
         }
 
-        //
+        // 위 케이스 외
+        throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE);
     }
 
     @Transactional

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -13,6 +13,9 @@ import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.profile.entity.ProfileLink;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
 import teamficial.teamficial_be.domain.profile.repository.ProfileRepository;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
+import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostService;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.domain.user.service.UserService;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
@@ -26,6 +29,7 @@ public class ProfileService {
     private final ApplicationService applicationService;
     private final ProfileRepository profileRepository;
     private final PreSignedUrlService preSignedUrlService;
+    private final RecruitingPostService recruitingPostService;
 
     @Transactional
     public ProfileResponseDto createProfile(User user, ProfileRequestDto requestDto, String objectKey){
@@ -88,19 +92,25 @@ public class ProfileService {
 
         // 이 프로필을 사용한 Application 존재하는지 확인
         List<Application> applications = applicationService.getApplicationsByProfile(profile);
-        if (!applications.isEmpty()) {
+        List<RecruitingPost> recruitingPosts  = recruitingPostService.getRecruitingPostsByProfile(profile);
+        if (!applications.isEmpty() || !recruitingPosts.isEmpty()) {
             // 존재한다면, applicationStatus 확인
-            boolean hasMatchable = applications.stream()
+            boolean applicationHasMatchable = applications.stream()
                     .anyMatch(app -> app.getApplicationStatus() == ApplicationStatus.MATCHED
                             || app.getApplicationStatus() == ApplicationStatus.MATCH_FAILED);
 
-            if (hasMatchable) {
+            boolean recruitingPostHasMatchable = recruitingPosts.stream()
+                    .anyMatch(recruitingPost -> recruitingPost.getStatus()== RecruitingStatus.CLOSED);
+
+            if (applicationHasMatchable && recruitingPostHasMatchable) {
                 // soft-delete 처리
                 profile.deleteProfile();
                 profileRepository.save(profile);
-            } else {
+            } else if (!applicationHasMatchable) {
                 // 매칭 대기 상태라면 삭제 금지
                 throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING);
+            } else if (!recruitingPostHasMatchable) {
+                throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN);
             }
         } else {
             // 3) Application이 아예 없다면 물리 삭제 가능
@@ -112,6 +122,8 @@ public class ProfileService {
             }
             profileRepository.delete(profile);
         }
+
+        //
     }
 
     @Transactional

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -45,7 +45,7 @@ public class ProfileService {
 
         int count = profileRepository.countByUser(user);
 
-        if (count > 3) {
+        if (count >= 3) {
             throw new GeneralException(ErrorStatus.CANNOT_COUNT_OVER_3);
         }
 
@@ -103,15 +103,21 @@ public class ProfileService {
         boolean hasAnyApplication = !applications.isEmpty();
         boolean hasMatchingApplication = applications.stream()
                 .anyMatch(a -> a.getApplicationStatus() == ApplicationStatus.MATCHING);
-        boolean hasMatchedOrFailedApplication = applications.stream()
-                .anyMatch(a -> a.getApplicationStatus() == ApplicationStatus.MATCHED
-                        || a.getApplicationStatus() == ApplicationStatus.MATCH_FAILED);
 
         boolean hasAnyPost = !recruitingPosts.isEmpty();
         boolean hasOpenPost = recruitingPosts.stream()
                 .anyMatch(p -> p.getStatus() == RecruitingStatus.OPEN);
-        boolean hasClosedPost = recruitingPosts.stream()
-                .anyMatch(p -> p.getStatus() == RecruitingStatus.CLOSED);
+
+        //하드삭제
+        if (!hasAnyApplication && !hasAnyPost) {
+            String image = profile.getProfileImage();
+            if (image != null && !image.isBlank()) {
+                String objectKey = preSignedUrlService.extractKeyFromUrl(image);
+                preSignedUrlService.deleteByKey(objectKey);
+            }
+            profileRepository.delete(profile);
+            return;
+        }
 
         boolean softDeleteAboutApp = false;
         //지원관련 필터링
@@ -142,17 +148,6 @@ public class ProfileService {
         if (softDeleteAboutRp && softDeleteAboutApp) {
             profile.deleteProfile();
             profileRepository.save(profile);
-            return;
-        }
-
-        // 하드 삭제
-        if (!hasAnyApplication && !hasAnyPost) {
-            String image = profile.getProfileImage();
-            if (image != null && !image.isBlank()) {
-                String objectKey = preSignedUrlService.extractKeyFromUrl(image);
-                preSignedUrlService.deleteByKey(objectKey);
-            }
-            profileRepository.delete(profile);
             return;
         }
 

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDTO.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDTO.java
@@ -76,6 +76,7 @@ public class RecruitingPostDTO {
         private Long writerProfileId;
         private String userName;         // 작성자 이름
         private String profileImageUrl;     // profile image url
+        private boolean profileIsDeleted;
 
         private ProgressWay progressWay;    // 진행 방식
         private String contactWay;          // 연락 방법
@@ -102,6 +103,7 @@ public class RecruitingPostDTO {
                     .writerProfileId(post.getProfile().getId())
                     .userName(post.getProfile().getUserName())
                     .profileImageUrl(post.getProfile().getProfileImage())
+                    .profileIsDeleted(post.getProfile().isDeleted())
                     .title(post.getTitle())
                     .content(post.getContent())
                     .progressWay(post.getProgressWay())

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
 import teamficial.teamficial_be.domain.user.entity.User;
@@ -40,4 +41,9 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
     @Modifying
     @Query("UPDATE RecruitingPost p SET p.status = 'CLOSED' WHERE p.deadline < :today AND p.status <> 'CLOSED'")
     int updateStatusToClosed(@Param("today") LocalDate today);
+
+    @Query("SELECT rp FROM RecruitingPost rp " +
+            "JOIN FETCH rp.profile p " +
+            "WHERE p = :profile")
+    List<RecruitingPost> findAllByProfile(Profile profile);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
@@ -1,6 +1,7 @@
 package teamficial.teamficial_be.domain.recruitingPost.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
 import org.hibernate.collection.spi.PersistentBag;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,7 @@ import teamficial.teamficial_be.global.enums.Position;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RecruitingPostService {
@@ -157,7 +159,7 @@ public class RecruitingPostService {
     }
 
     public void validatePostOwner(User user, RecruitingPost recruitingPost) {
-        Long writerId = recruitingPost.getProfile().getUser().getId();
+        Long writerId = recruitingPost.getUser().getId();
         if (!user.getId().equals(writerId)) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
@@ -191,4 +191,8 @@ public class RecruitingPostService {
     public List<RecruitingPost> getTop3ByUser(User user) {
         return recruitingPostRepository.findTop3ByUserOrderByDeadlineAsc(user);
     }
+
+    public List<RecruitingPost> getRecruitingPostsByProfile(Profile profile) {
+        return recruitingPostRepository.findAllByProfile(profile);
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -33,7 +33,8 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_DELETED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE4002" , "프로필 사진이 이미 삭제된 상태입니다."),
     PROFILE_FORBIDDEN(HttpStatus.FORBIDDEN,"PROFILE4003","프로필 수정 권한이 없습니다."),
     CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 지원중인 공고가 있어, 삭제가 불가능합니다."),
-    CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
+    CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4005","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
+    CANNOT_COUNT_OVER_3(HttpStatus.BAD_REQUEST,"PROFILE4005","사용자의 프로필 개수는 3개를 넘을 수 없습니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_DELETED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE4002" , "프로필 사진이 이미 삭제된 상태입니다."),
     PROFILE_FORBIDDEN(HttpStatus.FORBIDDEN,"PROFILE4003","프로필 수정 권한이 없습니다."),
     CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 지원중인 공고가 있어, 삭제가 불가능합니다."),
+    CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -34,8 +34,8 @@ public enum ErrorStatus implements BaseErrorCode {
     PROFILE_FORBIDDEN(HttpStatus.FORBIDDEN,"PROFILE4003","프로필 수정 권한이 없습니다."),
     CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 지원중인 공고가 있어, 삭제가 불가능합니다."),
     CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4005","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
-    CANNOT_COUNT_OVER_3(HttpStatus.BAD_REQUEST,"PROFILE4005","사용자의 프로필 개수는 3개를 넘을 수 없습니다."),
-    CANNOT_DELETE_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4006","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
+    CANNOT_COUNT_OVER_3(HttpStatus.BAD_REQUEST,"PROFILE4006","사용자의 프로필 개수는 3개를 넘을 수 없습니다."),
+    CANNOT_DELETE_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4007","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 지원중인 공고가 있어, 삭제가 불가능합니다."),
     CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4005","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
     CANNOT_COUNT_OVER_3(HttpStatus.BAD_REQUEST,"PROFILE4005","사용자의 프로필 개수는 3개를 넘을 수 없습니다."),
+    CANNOT_DELETE_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4006","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),

--- a/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Slf4j

--- a/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
+++ b/src/main/java/teamficial/teamficial_be/global/config/RedisConfig.java
@@ -28,13 +28,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
-
-        template.setConnectionFactory(redisConnectionFactory());
+        template.setConnectionFactory(factory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
-        template.setDefaultSerializer(new StringRedisSerializer());
         return template;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #86 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 모집 중인 작성글이 있거나 모집 글에 작성중인 상태라면 삭제 막기
지원 결과가 다 나와있고, 작성한 글이 없을 때 soft delete
지원한 적이 없고 작성한 글이 모집완료된 경우에는 soft delete
작성한 글도 없고 지원한 적도 없을 때는 hard delete

- [x] 프로필 개수 제한

### 스크린샷 (선택)
<img width="736" height="293" alt="image" src="https://github.com/user-attachments/assets/cc68d028-97cc-47e3-8687-b002422f0033" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자당 프로필 생성 개수 제한 도입(최대 3개)
  * 프로필 삭제 상태(isDeleted) 표시가 API 응답에 노출됨
  * 모집글 응답에 관련 프로필 삭제 여부 포함

* **버그 수정**
  * 프로필 삭제 로직 강화: 지원 상태와 모집 글 상태를 모두 고려한 하드/소프트 삭제 판단 및 관련 오류 처리 추가
  * 삭제 불가 상황에 대한 명확한 오류 코드/메시지 추가

* **성능**
  * 일부 조회에 읽기 전용 트랜잭션 적용으로 효율 향상
* **기타**
  * 프로필 수 확인을 위한 카운트 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->