### PR TITLE
[fix] 프로필 수정&삭제 로직

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/entity/Application.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/entity/Application.java
@@ -47,11 +47,9 @@ public class Application extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
 
     public void updateStatus(ApplicationStatus applicationStatus) {
         this.applicationStatus = applicationStatus;

--- a/src/main/java/teamficial/teamficial_be/domain/application/entity/ApplicationStatus.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/entity/ApplicationStatus.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ApplicationStatus {
     MATCHED("매칭 성공"),
+    TEMP_SAVED("임시저장"),
     MATCHING("매칭중"),
     MATCH_FAILED("매칭 실패");
 

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
@@ -81,6 +81,6 @@ public class MypageController {
     public ApiResponse<String> confirmedApplicant(@AuthenticationPrincipal AuthDetails authDetails, @PathVariable Long recruitingPostId, @PathVariable Long applicationId, @RequestParam ApplicationStatus applicationStatus){
         mypageService.confirmedApplicant(authDetails.user(),recruitingPostId,applicationId,applicationStatus);
 
-        return ApiResponse.onSuccess("함께할 사람이 생겼습니다!");
+        return ApiResponse.onSuccess("지원 결과를 수정하였습니다.");
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicationDetailResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/CurrentApplicationDetailResponseDto.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 import lombok.Getter;
 import teamficial.teamficial_be.domain.application.dto.response.ApplicantListResponseDto;
 import teamficial.teamficial_be.domain.application.entity.Application;
+import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.recruitingPost.dto.response.RecruitingPostResponseDto;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Builder
@@ -17,10 +19,18 @@ public class CurrentApplicationDetailResponseDto {
     private List<ApplicantListResponseDto> applicantList;
 
     public static CurrentApplicationDetailResponseDto from(RecruitingPost recruitingPost, List<Application> applications, long dDay) {
+
+
         return CurrentApplicationDetailResponseDto.builder()
                 .recruitingPost(RecruitingPostResponseDto.from(recruitingPost,dDay))
                 .applicantList(applications.stream()
-                        .map(application -> ApplicantListResponseDto.from(application.getId(),application.getApplicationStatus().getDescription(), application.getProfile(), application.getPosition()))
+                        .map(application -> {
+                                ApplicationStatus status = application.getApplicationStatus();
+                                if (status == ApplicationStatus.TEMP_SAVED){
+                                    status = ApplicationStatus.MATCHED;
+                                }
+                            return ApplicantListResponseDto.from(application.getId(),status.getDescription(), application.getProfile(), application.getPosition());
+                        })
                         .toList()
                 )
                 .build();

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -47,7 +47,16 @@ public class MypageService {
         Page<Application> applicationPage = applicationService.getApplicationsByUserAndStatus(user,pageable,applicationStatus);
 
         Page<MyApplicationResponseDto> dtoPage = applicationPage
-                .map(application -> MyApplicationResponseDto.of(application.getRecruitingPost(),application.getApplicationStatus().getDescription()));
+                .map(application -> {
+                    RecruitingPost recruitingPost = application.getRecruitingPost();
+                    ApplicationStatus status = application.getApplicationStatus();
+
+                    if (recruitingPost.getStatus() == RecruitingStatus.OPEN || status ==ApplicationStatus.TEMP_SAVED) {
+                        return MyApplicationResponseDto.of(application.getRecruitingPost(), ApplicationStatus.MATCHING.getDescription());
+                    }
+
+                    return MyApplicationResponseDto.of(application.getRecruitingPost(), ApplicationStatus.MATCHING.getDescription());
+                });
 
         return PagedResponse.of(dtoPage);
     }
@@ -201,9 +210,13 @@ public class MypageService {
                 .toList();
 
         List<MyApplicationResponseDto> applicationDtos = applicationList.stream()
-                .map(app -> MyApplicationResponseDto.of(
-                        app.getRecruitingPost(),
-                        app.getApplicationStatus().getDescription()))
+                .map(app -> {
+                    ApplicationStatus status = app.getApplicationStatus();
+                    if (status == ApplicationStatus.TEMP_SAVED) {
+                        return MyApplicationResponseDto.of(app.getRecruitingPost(), ApplicationStatus.TEMP_SAVED.getDescription());
+                    }
+                    return MyApplicationResponseDto.of(app.getRecruitingPost(), app.getApplicationStatus().getDescription());
+                })
                 .toList();
 
         return DashboardResponseDto.builder()

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -55,7 +55,7 @@ public class MypageService {
                         return MyApplicationResponseDto.of(application.getRecruitingPost(), ApplicationStatus.MATCHING.getDescription());
                     }
 
-                    return MyApplicationResponseDto.of(application.getRecruitingPost(), ApplicationStatus.MATCHING.getDescription());
+                    return MyApplicationResponseDto.of(application.getRecruitingPost(), status.getDescription());
                 });
 
         return PagedResponse.of(dtoPage);
@@ -157,8 +157,15 @@ public class MypageService {
         recruitingPost.closedRecruitingPost();
         List<Application> applications = applicationService.getApplicationsByRecruitingPost(recruitingPost);
         applications.stream()
-                .filter(app -> app.getApplicationStatus() == ApplicationStatus.MATCHING)
-                .forEach(app -> app.updateStatus(ApplicationStatus.MATCH_FAILED));
+                .filter(app -> app.getApplicationStatus() == ApplicationStatus.MATCHING
+                        || app.getApplicationStatus() == ApplicationStatus.TEMP_SAVED)
+                .forEach(app -> {
+                    if (app.getApplicationStatus() == ApplicationStatus.TEMP_SAVED) {
+                        app.updateStatus(ApplicationStatus.MATCHED);
+                    } else {
+                        app.updateStatus(ApplicationStatus.MATCH_FAILED);
+                    }
+                });
 
         applicationService.saveApplications(applications);
     }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/ProfileStatus.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/ProfileStatus.java
@@ -1,0 +1,43 @@
+package teamficial.teamficial_be.domain.profile.dto;
+
+import lombok.Builder;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
+
+@Builder
+public record ProfileStatus(boolean hasAnyApplication, boolean hasMatchingApplication, boolean hasAnyPost,
+                            boolean hasOpenPost) {
+    public boolean canModifyOrDelete() {
+        if (!hasAnyApplication && !hasAnyPost) {
+            return true;
+        }
+
+        boolean applicationAllowsModification = !hasAnyApplication || !hasMatchingApplication;
+
+        boolean postAllowsModification = !hasAnyPost || !hasOpenPost;
+
+        return applicationAllowsModification && postAllowsModification;
+    }
+
+    public boolean canHardDelete() {
+        return !hasAnyApplication && !hasAnyPost;
+    }
+
+    public void validateForModification() {
+        if (hasMatchingApplication) {
+            throw new GeneralException(ErrorStatus.CANNOT_MODIFY_PROFILE_WHEN_APPLICATION_PENDING);
+        }
+        if (hasOpenPost) {
+            throw new GeneralException(ErrorStatus.CANNOT_MODIFY_PROFILE_WHEN_RECRUITING_POST_OPEN);
+        }
+    }
+
+    public void validateForDeletion() {
+        if (hasMatchingApplication) {
+            throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING);
+        }
+        if (hasOpenPost) {
+            throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_RECRUITING_POST_OPEN);
+        }
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -6,18 +6,16 @@ import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.application.service.ApplicationService;
-import teamficial.teamficial_be.domain.keyword.service.HeadKeywordService;
+import teamficial.teamficial_be.domain.profile.dto.ProfileStatus;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
-import teamficial.teamficial_be.domain.profile.entity.ProfileLink;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
 import teamficial.teamficial_be.domain.profile.repository.ProfileRepository;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
 import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostService;
 import teamficial.teamficial_be.domain.user.entity.User;
-import teamficial.teamficial_be.domain.user.service.UserService;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 
@@ -67,19 +65,27 @@ public class ProfileService {
     }
 
     @Transactional
-    public ProfileResponseDto updateProfile(User user,Long profileId, ProfileRequestDto requestDto){
+    public ProfileResponseDto updateProfile(User user,Long profileId, ProfileRequestDto requestDto) {
         Profile profile = getProfileById(profileId);
-        profile.update(requestDto);
 
         validateUserProfile(user, profile);
 
+        ProfileStatus status = checkProfileStatus(profile);
+
+        if (!status.canModifyOrDelete()){
+            status.validateForModification();
+            throw new GeneralException(ErrorStatus.CANNOT_MODIFY_PROFILE);
+        }
+
+        profile.update(requestDto);
+
         if (requestDto.getLinks() != null) {
             profile.clearLinks();
-            requestDto.getLinks().forEach(link -> profile.addLink(link));
+            requestDto.getLinks().forEach(profile::addLink);
         }
 
         profileRepository.save(profile);
-        return ProfileResponseDto.of(profile,profile.getHeadKeywords());
+        return ProfileResponseDto.of(profile, profile.getHeadKeywords());
     }
 
     @Transactional(readOnly = true)
@@ -96,20 +102,9 @@ public class ProfileService {
 
         validateUserProfile(user, profile);
 
-        // 이 프로필을 사용한 Application 존재하는지 확인
-        List<Application> applications = applicationService.getApplicationsByProfile(profile);
-        List<RecruitingPost> recruitingPosts  = recruitingPostService.getRecruitingPostsByProfile(profile);
+        ProfileStatus status = checkProfileStatus(profile);
 
-        boolean hasAnyApplication = !applications.isEmpty();
-        boolean hasMatchingApplication = applications.stream()
-                .anyMatch(a -> a.getApplicationStatus() == ApplicationStatus.MATCHING);
-
-        boolean hasAnyPost = !recruitingPosts.isEmpty();
-        boolean hasOpenPost = recruitingPosts.stream()
-                .anyMatch(p -> p.getStatus() == RecruitingStatus.OPEN);
-
-        //하드삭제
-        if (!hasAnyApplication && !hasAnyPost) {
+        if (status.canHardDelete()){
             String image = profile.getProfileImage();
             if (image != null && !image.isBlank()) {
                 String objectKey = preSignedUrlService.extractKeyFromUrl(image);
@@ -119,40 +114,13 @@ public class ProfileService {
             return;
         }
 
-        boolean softDeleteAboutApp = false;
-        //지원관련 필터링
-        if (hasAnyApplication) {
-            if (hasMatchingApplication) {
-                throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING);
-            } else {
-                softDeleteAboutApp = true;
-            }
-        } else {
-            softDeleteAboutApp = true;
+        if (!status.canModifyOrDelete()){
+            status.validateForDeletion();
+            throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE);
         }
 
-        boolean softDeleteAboutRp = false;
-        //모집글 관련 필터링
-        if (hasAnyPost) {
-            if (hasOpenPost) {
-                throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN);
-            }
-            else {
-                softDeleteAboutRp = true;
-            }
-        } else {
-            softDeleteAboutRp = true;
-        }
-
-        // 소프트 삭제
-        if (softDeleteAboutRp && softDeleteAboutApp) {
-            profile.deleteProfile();
-            profileRepository.save(profile);
-            return;
-        }
-
-        // 위 케이스 외
-        throw new GeneralException(ErrorStatus.CANNOT_DELETE_PROFILE);
+        profile.deleteProfile();
+        profileRepository.save(profile);
     }
 
     @Transactional
@@ -208,5 +176,26 @@ public class ProfileService {
 
     public void saveProfile(Profile profile) {
         profileRepository.save(profile);
+    }
+
+    private ProfileStatus checkProfileStatus(Profile profile){
+        //이 프로필의 application 또는 작성한 recruitingPost 있는지
+        List<Application> applications = applicationService.getApplicationsByProfile(profile);
+        List<RecruitingPost> recruitingPosts = recruitingPostService.getRecruitingPostsByProfile(profile);
+
+        boolean hasAnyApplication = !applications.isEmpty();
+        boolean hasMatchingApplication = applications.stream()
+                .anyMatch(a -> a.getApplicationStatus() == ApplicationStatus.MATCHING || a.getApplicationStatus() == ApplicationStatus.TEMP_SAVED);
+
+        boolean hasAnyPost = !recruitingPosts.isEmpty();
+        boolean hasOpenPost = recruitingPosts.stream()
+                .anyMatch(p -> p.getStatus() == RecruitingStatus.OPEN);
+
+        return ProfileStatus.builder()
+                .hasMatchingApplication(hasMatchingApplication)
+                .hasAnyApplication(hasAnyApplication)
+                .hasAnyPost(hasAnyPost)
+                .hasOpenPost(hasOpenPost)
+                .build();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -38,7 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CANNOT_DELETE_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4007","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
     CANNOT_MODIFY_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4008","해당 프로필로 지원중인 공고가 있어, 수정이 불가능합니다."),
     CANNOT_MODIFY_PROFILE_WHEN_RECRUITING_POST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4009","해당 프로필로 모집 중인 작성 글이 있어, 수정이 불가능합니다."),
-    CANNOT_MODIFY_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4010","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
+    CANNOT_MODIFY_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4010","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 수정이 불가능합니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -33,15 +33,21 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_DELETED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE4002" , "프로필 사진이 이미 삭제된 상태입니다."),
     PROFILE_FORBIDDEN(HttpStatus.FORBIDDEN,"PROFILE4003","프로필 수정 권한이 없습니다."),
     CANNOT_DELETE_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4004","해당 프로필로 지원중인 공고가 있어, 삭제가 불가능합니다."),
-    CANNOT_DELETE_PROFILE_WHEN_RECRUITINGPOST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4005","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
+    CANNOT_DELETE_PROFILE_WHEN_RECRUITING_POST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4005","해당 프로필로 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
     CANNOT_COUNT_OVER_3(HttpStatus.BAD_REQUEST,"PROFILE4006","사용자의 프로필 개수는 3개를 넘을 수 없습니다."),
     CANNOT_DELETE_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4007","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
+    CANNOT_MODIFY_PROFILE_WHEN_APPLICATION_PENDING(HttpStatus.BAD_REQUEST,"PROFILE4008","해당 프로필로 지원중인 공고가 있어, 수정이 불가능합니다."),
+    CANNOT_MODIFY_PROFILE_WHEN_RECRUITING_POST_OPEN(HttpStatus.BAD_REQUEST,"PROFILE4009","해당 프로필로 모집 중인 작성 글이 있어, 수정이 불가능합니다."),
+    CANNOT_MODIFY_PROFILE(HttpStatus.BAD_REQUEST,"PROFILE4010","해당 프로필로 지원중인 공고나 모집 중인 작성 글이 있어, 삭제가 불가능합니다."),
 
     //지원 관련 응답
     DUPLICATE_APPLICATION(HttpStatus.BAD_REQUEST,"APPLICATION6001","이미 지원한 모집 글 입니다."),
 
     //키워드 관련 응답
     KEYWORD_FORBIDDEN(HttpStatus.FORBIDDEN,"KEYWORD4003","키워드 설정 권한이 없습니다."),
+
+
+
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #88 

## 📝작업 내용

> 임시저장을 추가하면서 지원 상태에 temp_save를 추가하였다.
그리고 지원자와 모집 글 작성자는 모집 마감이 되기 전까지 프로필 삭제 및 수정이 안되므로 이에 맞게 에러 처리를 추가했다

- [x] 지원 상태에 임시 저장 추가
- [x] 프로필 삭제& 수정 로직 재구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지원서에 '임시저장' 상태가 추가되었습니다.
  * 프로필 수정·삭제 전 상태 검증 로직이 추가되어 제한 조건이 적용됩니다.

* **버그 수정**
  * 지원 상태 표시가 더 일관되게 표시되도록 개선되었습니다.
  * 마이페이지 성공 안내 문구가 업데이트되었습니다.

* **리팩터링**
  * 프로필 관련 상태 관리 로직이 통합·단순화되었습니다.
* **기타**
  * 지원서의 외부 연결 및 공개적 직접 수정 경로가 제거되어 동작이 제어됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->