### PR TITLE
pr Feat/지원 마감시 프로필 스냅샷 저장

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/controller/ApplicationController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/controller/ApplicationController.java
@@ -10,7 +10,6 @@ import teamficial.teamficial_be.domain.application.service.ApplicationService;
 import teamficial.teamficial_be.global.security.AuthDetails;
 import teamficial.teamficial_be.global.util.GlobalAuthUtil;
 
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/applications")

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileController.java
@@ -1,12 +1,31 @@
 package teamficial.teamficial_be.domain.confirmed;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import teamficial.teamficial_be.domain.confirmed.dto.response.ConfirmedProfileResponse;
+import teamficial.teamficial_be.global.enums.Position;
+import teamficial.teamficial_be.global.security.AuthDetails;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class ConfirmedProfileController {
 
+    private final ConfirmedProfileService confirmedProfileService;
+
+    @GetMapping("/confirmed-profile/{postId}")
+    public List<ConfirmedProfileResponse> getConfirmedProfiles(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long postId,
+            @RequestParam(required = false) Position position
+    ) {
+        return confirmedProfileService.getConfirmedProfileByPostId(authDetails.user(), postId, position);
+    }
 
 
 }

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileController.java
@@ -1,5 +1,6 @@
 package teamficial.teamficial_be.domain.confirmed;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,7 @@ public class ConfirmedProfileController {
     private final ConfirmedProfileService confirmedProfileService;
 
     @GetMapping("/confirmed-profile/{postId}")
+    @Operation(summary = "나의 팀 멤버 프로필 확인하기 API", description = "프로젝트 모집 완료 글의 멤버 프로필 조회 API입니다.")
     public List<ConfirmedProfileResponse> getConfirmedProfiles(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long postId,

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileController.java
@@ -1,0 +1,12 @@
+package teamficial.teamficial_be.domain.confirmed;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ConfirmedProfileController {
+
+
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
@@ -3,23 +3,33 @@ package teamficial.teamficial_be.domain.confirmed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import teamficial.teamficial_be.domain.confirmed.dto.response.ConfirmedProfileResponse;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedHeadKeyword;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileLink;
-import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileRepository;
+import teamficial.teamficial_be.domain.confirmed.repository.ConfirmedProfileRepository;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.domain.profile.service.ProfileService;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
+import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostService;
+import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.enums.Position;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ConfirmedProfileService {
 
     private final ConfirmedProfileRepository confirmedProfileRepository;
+    private final ProfileService profileService;
+    private final RecruitingPostService recruitingPostService;
 
     @Transactional
-    public void createSnapshotFrom(Profile profile, Position position) {
+    public void createSnapshotFrom(Profile profile, Position position, RecruitingPost recruitingPost) {
 
         ConfirmedProfile confirmed = ConfirmedProfile.builder()
+                .recruitingPost(recruitingPost)
                 .userName(profile.getUser().getName())
                 .profileName(profile.getProfileName())
                 .profileImage(profile.getProfileImage())
@@ -45,7 +55,19 @@ public class ConfirmedProfileService {
                                 .build()
                 )
         );
-
         confirmedProfileRepository.save(confirmed);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConfirmedProfileResponse> getConfirmedProfileByPostId(User user, Long postId, Position position) {
+        RecruitingPost recruitingPost = recruitingPostService.getRecruitingPostById(postId);
+        profileService.validateUserProfile(user,recruitingPost.getProfile());
+
+        List<ConfirmedProfile> confirmedProfiles =
+                confirmedProfileRepository.findByPostIdAndPosition(postId, position);
+
+        return confirmedProfiles.stream()
+                .map(ConfirmedProfileResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
@@ -2,6 +2,8 @@ package teamficial.teamficial_be.domain.confirmed;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedHeadKeyword;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileLink;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileRepository;
@@ -13,7 +15,8 @@ public class ConfirmedProfileService {
 
     private final ConfirmedProfileRepository confirmedProfileRepository;
 
-    public ConfirmedProfile createSnapshotFrom(Profile profile) {
+    @Transactional
+    public void createSnapshotFrom(Profile profile) {
 
         ConfirmedProfile confirmed = ConfirmedProfile.builder()
                 .userName(profile.getUser().getName())
@@ -32,6 +35,15 @@ public class ConfirmedProfileService {
                 )
         );
 
-        return confirmedProfileRepository.save(confirmed);
+        profile.getHeadKeywords().forEach(hk ->
+                confirmed.addHeadKeyword(
+                        ConfirmedHeadKeyword.builder()
+                                .confirmedProfile(confirmed)
+                                .keywordName(hk.getKeywordName())
+                                .build()
+                )
+        );
+
+        confirmedProfileRepository.save(confirmed);
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
@@ -8,6 +8,7 @@ import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileLink;
 import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileRepository;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.global.enums.Position;
 
 @Service
 @RequiredArgsConstructor
@@ -16,7 +17,7 @@ public class ConfirmedProfileService {
     private final ConfirmedProfileRepository confirmedProfileRepository;
 
     @Transactional
-    public void createSnapshotFrom(Profile profile) {
+    public void createSnapshotFrom(Profile profile, Position position) {
 
         ConfirmedProfile confirmed = ConfirmedProfile.builder()
                 .userName(profile.getUser().getName())
@@ -24,6 +25,7 @@ public class ConfirmedProfileService {
                 .profileImage(profile.getProfileImage())
                 .workingTime(profile.getWorkingTime())
                 .contactWay(profile.getContactWay())
+                .position(position)
                 .build();
 
         profile.getProfileLinks().forEach(link ->

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/ConfirmedProfileService.java
@@ -1,0 +1,37 @@
+package teamficial.teamficial_be.domain.confirmed;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileLink;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfileRepository;
+import teamficial.teamficial_be.domain.profile.entity.Profile;
+
+@Service
+@RequiredArgsConstructor
+public class ConfirmedProfileService {
+
+    private final ConfirmedProfileRepository confirmedProfileRepository;
+
+    public ConfirmedProfile createSnapshotFrom(Profile profile) {
+
+        ConfirmedProfile confirmed = ConfirmedProfile.builder()
+                .userName(profile.getUser().getName())
+                .profileName(profile.getProfileName())
+                .profileImage(profile.getProfileImage())
+                .workingTime(profile.getWorkingTime())
+                .contactWay(profile.getContactWay())
+                .build();
+
+        profile.getProfileLinks().forEach(link ->
+                confirmed.addProfileLink(
+                        ConfirmedProfileLink.builder()
+                                .confirmedProfile(confirmed)
+                                .link(link.getLink())
+                                .build()
+                )
+        );
+
+        return confirmedProfileRepository.save(confirmed);
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/dto/response/ConfirmedProfileResponse.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/dto/response/ConfirmedProfileResponse.java
@@ -1,0 +1,58 @@
+package teamficial.teamficial_be.domain.confirmed.dto.response;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
+import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
+import teamficial.teamficial_be.global.enums.Position;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmedProfileResponse {
+    private String userName;
+
+    private String profileName;
+
+    private String profileImage;
+
+    private WorkingTime workingTime;
+
+    private String contactWay;
+
+    private Position position;
+
+    private List<String> keywords;
+
+    private List<String> links;
+
+    public static ConfirmedProfileResponse from(ConfirmedProfile profile) {
+
+        List<String> keywordList = profile.getConfirmedHeadKeywords().stream()
+                .map(hk -> hk.getKeywordName())
+                .toList();
+
+        List<String> linkList = profile.getConfirmedProfileLinks().stream()
+                .map(l -> l.getLink())
+                .toList();
+
+        return ConfirmedProfileResponse.builder()
+                .userName(profile.getUserName())
+                .profileName(profile.getProfileName())
+                .profileImage(profile.getProfileImage())
+                .workingTime(profile.getWorkingTime())
+                .contactWay(profile.getContactWay())
+                .position(profile.getPosition())
+                .keywords(keywordList)
+                .links(linkList)
+                .build();
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedHeadKeyword.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedHeadKeyword.java
@@ -1,0 +1,28 @@
+package teamficial.teamficial_be.domain.confirmed.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConfirmedHeadKeyword extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "confirmed_head_keyword_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "confirmed_profile_id")
+    private ConfirmedProfile confirmedProfile;
+
+    @Column(name = "keyword_name", length = 50)
+    private String keywordName;
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedHeadKeyword.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedHeadKeyword.java
@@ -1,15 +1,13 @@
 package teamficial.teamficial_be.domain.confirmed.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.global.entity.BaseEntity;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
@@ -48,5 +48,8 @@ public class ConfirmedProfile extends BaseEntity {
         profileLink.setConfirmedProfile(this);
     }
 
-
+    public void addHeadKeyword(ConfirmedHeadKeyword keyword) {
+        confirmedHeadKeywords.add(keyword);
+        keyword.setConfirmedProfile(this);
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
 import teamficial.teamficial_be.global.entity.BaseEntity;
+import teamficial.teamficial_be.global.enums.Position;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,8 @@ public class ConfirmedProfile extends BaseEntity {
 
     @Column(name = "contact_way", length = 255)
     private String contactWay;
+
+    private Position position;
 
     public void addProfileLink(ConfirmedProfileLink profileLink) {
         confirmedProfileLinks.add(profileLink);

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
@@ -3,6 +3,7 @@ package teamficial.teamficial_be.domain.confirmed.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
+import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.global.entity.BaseEntity;
 import teamficial.teamficial_be.global.enums.Position;
 
@@ -19,6 +20,10 @@ public class ConfirmedProfile extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "confirmed_profile_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruiting_post_id", nullable = false)
+    private RecruitingPost recruitingPost;
 
     @OneToMany(mappedBy = "confirmedProfile",cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @Builder.Default

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfile.java
@@ -1,0 +1,52 @@
+package teamficial.teamficial_be.domain.confirmed.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
+import teamficial.teamficial_be.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConfirmedProfile extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "confirmed_profile_id")
+    private Long id;
+
+    @OneToMany(mappedBy = "confirmedProfile",cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Builder.Default
+    private List<ConfirmedProfileLink> confirmedProfileLinks= new ArrayList<>();
+
+    @OneToMany(mappedBy = "confirmedProfile",cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Builder.Default
+    private List<ConfirmedHeadKeyword> confirmedHeadKeywords = new ArrayList<>();
+
+    @Column(name = "user_name", length = 50, nullable = false)
+    private String userName;
+
+    @Column(name = "profile_name", length = 50)
+    private String profileName;
+
+    @Column(name = "profile_image", length = 255)
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "working_time")
+    private WorkingTime workingTime;
+
+    @Column(name = "contact_way", length = 255)
+    private String contactWay;
+
+    public void addProfileLink(ConfirmedProfileLink profileLink) {
+        confirmedProfileLinks.add(profileLink);
+        profileLink.setConfirmedProfile(this);
+    }
+
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfileLink.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfileLink.java
@@ -1,0 +1,23 @@
+package teamficial.teamficial_be.domain.confirmed.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConfirmedProfileLink {
+    @Id @Column(name = "confirmed_profile_link_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "confirmed_profile_id", nullable = false)
+    private ConfirmedProfile confirmedProfile;
+
+    @Column(name = "link", length = 255)
+    private String link;
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfileRepository.java
@@ -1,8 +1,0 @@
-package teamficial.teamficial_be.domain.confirmed.entity;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ConfirmedProfileRepository extends JpaRepository<ConfirmedProfile, Long> {
-}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/entity/ConfirmedProfileRepository.java
@@ -1,0 +1,8 @@
+package teamficial.teamficial_be.domain.confirmed.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConfirmedProfileRepository extends JpaRepository<ConfirmedProfile, Long> {
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/repository/ConfirmedProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/repository/ConfirmedProfileRepository.java
@@ -1,0 +1,9 @@
+package teamficial.teamficial_be.domain.confirmed.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
+
+@Repository
+public interface ConfirmedProfileRepository extends JpaRepository<ConfirmedProfile, Long>, ConfirmedProfileRepositoryCustom {
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/repository/ConfirmedProfileRepositoryCustom.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/repository/ConfirmedProfileRepositoryCustom.java
@@ -1,0 +1,10 @@
+package teamficial.teamficial_be.domain.confirmed.repository;
+
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
+import teamficial.teamficial_be.global.enums.Position;
+
+import java.util.List;
+
+public interface ConfirmedProfileRepositoryCustom {
+    List<ConfirmedProfile> findByPostIdAndPosition(Long postId, Position position);
+}

--- a/src/main/java/teamficial/teamficial_be/domain/confirmed/repository/ConfirmedProfileRepositoryImpl.java
+++ b/src/main/java/teamficial/teamficial_be/domain/confirmed/repository/ConfirmedProfileRepositoryImpl.java
@@ -1,0 +1,41 @@
+package teamficial.teamficial_be.domain.confirmed.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import teamficial.teamficial_be.domain.confirmed.entity.ConfirmedProfile;
+import teamficial.teamficial_be.domain.confirmed.entity.QConfirmedHeadKeyword;
+import teamficial.teamficial_be.domain.confirmed.entity.QConfirmedProfile;
+import teamficial.teamficial_be.domain.confirmed.entity.QConfirmedProfileLink;
+import teamficial.teamficial_be.global.enums.Position;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ConfirmedProfileRepositoryImpl implements ConfirmedProfileRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    QConfirmedProfileLink link = QConfirmedProfileLink.confirmedProfileLink;
+    QConfirmedHeadKeyword keyword = QConfirmedHeadKeyword.confirmedHeadKeyword;
+    QConfirmedProfile cp = QConfirmedProfile.confirmedProfile;
+
+    @Override
+    public List<ConfirmedProfile> findByPostIdAndPosition(Long postId, Position position) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(cp.recruitingPost.id.eq(postId));
+
+        if (position != null) {
+            builder.and(cp.position.eq(position));
+        }
+
+        return queryFactory
+                .selectDistinct(cp)
+                .from(cp)
+                .leftJoin(cp.confirmedProfileLinks, link).fetchJoin()
+                .where(builder)
+                .orderBy(cp.id.desc())
+                .fetch();
+        }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/controller/TeamficialLogController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/controller/TeamficialLogController.java
@@ -65,10 +65,9 @@ public class TeamficialLogController {
     @PostMapping("/teamficial-log")
     @Operation(summary = "팀피셜록 작성하기", description = "팀피셜록을 작성하고 키워드,요약을 추출하는 api 입니다.")
     public ApiResponse<TeamficialLogResponseDto> createTeamficialLog(
-            @AuthenticationPrincipal AuthDetails authDetails,
             @Valid @RequestBody TeamficialLogRequestDto request) throws IOException {
 
-        return ApiResponse.onSuccess(teamficialLogService.createTeamficialLog(authDetails.user(), request));
+        return ApiResponse.onSuccess(teamficialLogService.createTeamficialLog(request));
     }
 
 }

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
@@ -131,7 +131,7 @@ public class TeamficialLogService {
         return ScrollResponse.of(dtoList);
     }
 
-    public TeamficialLogResponseDto createTeamficialLog(User writer, TeamficialLogRequestDto req) throws IOException {
+    public TeamficialLogResponseDto createTeamficialLog(TeamficialLogRequestDto req) throws IOException {
 
         List<String> contents = List.of(
                 req.getContent1(),

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -176,7 +176,7 @@ public class MypageService {
                     if (app.getApplicationStatus() == ApplicationStatus.MATCHED) {
                         Profile profile = profileService.getProfileWithLinksAndKeywords(app.getProfile().getId());
 
-                        confirmedProfileService.createSnapshotFrom(profile);
+                        confirmedProfileService.createSnapshotFrom(profile, app.getPosition());
                     }
 
                 });

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -46,6 +46,8 @@ public class MypageService {
     private final RedisService redisService;
     private final ProfileService profileService;
     private final ConfirmedProfileService confirmedProfileService;
+    private final HeadKeywordService headKeywordService;
+
 
     @Transactional(readOnly = true)
     public PagedResponse<MyApplicationResponseDto> getAllApplications(User user, int page, int size,ApplicationStatus applicationStatus) {
@@ -174,9 +176,10 @@ public class MypageService {
                     }
 
                     if (app.getApplicationStatus() == ApplicationStatus.MATCHED) {
-                        Profile profile = profileService.getProfileWithLinksAndKeywords(app.getProfile().getId());
+                        Profile profile = profileService.getProfileWithLinks(app.getProfile().getId());
+                        profile.getHeadKeywords().size();
 
-                        confirmedProfileService.createSnapshotFrom(profile, app.getPosition());
+                        confirmedProfileService.createSnapshotFrom(profile, app.getPosition(), recruitingPost);
                     }
 
                 });

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -12,9 +12,14 @@ import teamficial.teamficial_be.domain.application.dto.response.ApplicationRespo
 import teamficial.teamficial_be.domain.application.entity.Application;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.application.service.ApplicationService;
+import teamficial.teamficial_be.domain.confirmed.ConfirmedProfileService;
+import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
+import teamficial.teamficial_be.domain.keyword.service.HeadKeywordService;
 import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicantResponseDto;
 import teamficial.teamficial_be.domain.myPage.dto.response.DashboardResponseDto;
 import teamficial.teamficial_be.domain.myPage.dto.response.MyApplicationResponseDto;
+import teamficial.teamficial_be.domain.profile.entity.Profile;
+import teamficial.teamficial_be.domain.profile.service.ProfileService;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
 import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostService;
@@ -39,6 +44,8 @@ public class MypageService {
     private final RecruitingPostService recruitingPostService;
     private final ApplicationService applicationService;
     private final RedisService redisService;
+    private final ProfileService profileService;
+    private final ConfirmedProfileService confirmedProfileService;
 
     @Transactional(readOnly = true)
     public PagedResponse<MyApplicationResponseDto> getAllApplications(User user, int page, int size,ApplicationStatus applicationStatus) {
@@ -145,7 +152,7 @@ public class MypageService {
         recruitingPost.getDDay();
 
 
-        return CurrentApplicationDetailResponseDto.from(recruitingPost, applications,dDay);
+        return CurrentApplicationDetailResponseDto.from(recruitingPost, applications, dDay);
     }
 
     @Transactional
@@ -165,6 +172,13 @@ public class MypageService {
                     } else {
                         app.updateStatus(ApplicationStatus.MATCH_FAILED);
                     }
+
+                    if (app.getApplicationStatus() == ApplicationStatus.MATCHED) {
+                        Profile profile = profileService.getProfileById(app.getProfile().getId());
+
+                        confirmedProfileService.createSnapshotFrom(profile);
+                    }
+
                 });
 
         applicationService.saveApplications(applications);

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -174,7 +174,7 @@ public class MypageService {
                     }
 
                     if (app.getApplicationStatus() == ApplicationStatus.MATCHED) {
-                        Profile profile = profileService.getProfileById(app.getProfile().getId());
+                        Profile profile = profileService.getProfileWithLinksAndKeywords(app.getProfile().getId());
 
                         confirmedProfileService.createSnapshotFrom(profile);
                     }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
@@ -8,6 +8,7 @@ import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.user.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
@@ -16,4 +17,10 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     @Query("select count(p) from Profile  p where p.user = :user and p.isDeleted = false")
     int countByUser(User user);
+
+    @Query("SELECT p FROM Profile p " +
+            "LEFT JOIN FETCH p.profileLinks " +
+            "LEFT JOIN FETCH p.headKeywords " +
+            "WHERE p.id = :id")
+    Optional<Profile> findWithLinksAndKeywordsById(@Param("id") Long id);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/repository/ProfileRepository.java
@@ -20,7 +20,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     @Query("SELECT p FROM Profile p " +
             "LEFT JOIN FETCH p.profileLinks " +
-            "LEFT JOIN FETCH p.headKeywords " +
             "WHERE p.id = :id")
-    Optional<Profile> findWithLinksAndKeywordsById(@Param("id") Long id);
+    Optional<Profile> findWithLinksById(@Param("id") Long id);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -169,7 +169,7 @@ public class ProfileService {
                 .toList();
     }
 
-    private void validateUserProfile(User user,Profile profile) {
+    public void validateUserProfile(User user,Profile profile) {
         if(!user.getId().equals(profile.getUser().getId())) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
@@ -201,8 +201,8 @@ public class ProfileService {
     }
 
     @Transactional(readOnly = true)
-    public Profile getProfileWithLinksAndKeywords(Long profileId) {
-        return profileRepository.findWithLinksAndKeywordsById(profileId)
+    public Profile getProfileWithLinks(Long profileId) {
+        return profileRepository.findWithLinksById(profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -18,6 +18,7 @@ import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostServ
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
+import teamficial.teamficial_be.global.apiPayload.exception.handler.NotFoundHandler;
 
 import java.util.List;
 
@@ -197,5 +198,11 @@ public class ProfileService {
                 .hasAnyPost(hasAnyPost)
                 .hasOpenPost(hasOpenPost)
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Profile getProfileWithLinksAndKeywords(Long profileId) {
+        return profileRepository.findWithLinksAndKeywordsById(profileId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
     }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepositoryImpl.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepositoryImpl.java
@@ -1,12 +1,9 @@
 package teamficial.teamficial_be.domain.recruitingPost.repository;
 
-import com.amazonaws.event.request.Progress;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.collection.spi.PersistentBag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -27,7 +24,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RecruitingPostRepositoryImpl implements RecruitingPostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
-
 
     @Override
     public Page<RecruitingPostDTO.RecruitingPostsResponseDTO> findByFilters(


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #91 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [ ] 확정 프로필 테이블 생성
- [ ] 지원 마감시 스냅샷 저장 로직 추가
- [ ] 확정 프로필 조회 API 구현 - 직무 필터링 추가
- [ ] 로그인 확인 여부 로직 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채용 공고별 확정된 프로필 조회 기능 추가 (위치 필터링 옵션 포함)
  * 지원자 프로필의 스냅샷 자동 생성 기능 추가

* **개선사항**
  * 팀피셜 로그 생성 API 최적화
  * 프로필 정보 조회 성능 개선

* **정리**
  * 불필요한 코드 정리 및 포매팅 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->