### PR TITLE
[feat] 팀피셜록 요청자의 정보 반환 api 구현

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/keyword/controller/TeamficialLogController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/controller/TeamficialLogController.java
@@ -8,10 +8,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import teamficial.teamficial_be.domain.keyword.dto.request.HeadKeywordRequestDto;
 import teamficial.teamficial_be.domain.keyword.dto.request.TeamficialLogRequestDto;
-import teamficial.teamficial_be.domain.keyword.dto.response.HeadKeywordResponseDto;
-import teamficial.teamficial_be.domain.keyword.dto.response.KeywordCommentResponseDto;
-import teamficial.teamficial_be.domain.keyword.dto.response.KeywordResponseDto;
-import teamficial.teamficial_be.domain.keyword.dto.response.TeamficialLogResponseDto;
+import teamficial.teamficial_be.domain.keyword.dto.response.*;
 import teamficial.teamficial_be.domain.keyword.service.TeamficialLogService;
 import teamficial.teamficial_be.global.apiPayload.ApiResponse;
 import teamficial.teamficial_be.global.security.AuthDetails;
@@ -68,6 +65,14 @@ public class TeamficialLogController {
             @Valid @RequestBody TeamficialLogRequestDto request) throws IOException {
 
         return ApiResponse.onSuccess(teamficialLogService.createTeamficialLog(request));
+    }
+
+    @GetMapping("/teamficial-log/requester")
+    @Operation(summary = "팀피셜록 요청자의 정보 반환 api")
+    public ApiResponse<TeamficialLogRequesterResponseDto> getTeamficialLogRequester(@RequestParam String requesterUuid) {
+        TeamficialLogRequesterResponseDto responseDto = teamficialLogService.getTeamficialLogRequester(requesterUuid);
+
+        return ApiResponse.onSuccess(responseDto);
     }
 
 }

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/dto/response/TeamficialLogRequesterResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/dto/response/TeamficialLogRequesterResponseDto.java
@@ -1,0 +1,11 @@
+package teamficial.teamficial_be.domain.keyword.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamficialLogRequesterResponseDto {
+    private Long requesterId;
+    private String requesterName;
+}

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
@@ -206,8 +206,12 @@ public class TeamficialLogService {
     }
 
 
+    public TeamficialLogRequesterResponseDto getTeamficialLogRequester(String requesterUuid) {
+        User user = userService.getUserByUuid(requesterUuid);
 
-
-
-
+        return TeamficialLogRequesterResponseDto.builder()
+                .requesterId(user.getId())
+                .requesterName(user.getName())
+                .build();
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/repository/UserRepository.java
@@ -6,4 +6,7 @@ import teamficial.teamficial_be.domain.user.entity.User;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmailAndDeletedAtIsNull(String email);}
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    Optional<User> findByUuidAndDeletedAtIsNull(String uuid);
+}

--- a/src/main/java/teamficial/teamficial_be/domain/user/service/UserService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/user/service/UserService.java
@@ -18,4 +18,9 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(()->new GeneralException(ErrorStatus.NOT_FOUND_USER));
     }
+
+    public User getUserByUuid(String requesterUuid) {
+        return userRepository.findByUuidAndDeletedAtIsNull(requesterUuid)
+                .orElseThrow(()->new GeneralException(ErrorStatus.NOT_FOUND_USER));
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #93 

## 📝작업 내용

> 팀피셜록 요청자의 정보를 반환하는 api를 구현하였다

<img width="737" height="144" alt="image" src="https://github.com/user-attachments/assets/c01a9ffa-3781-420d-8c2b-c387f1b47113" />

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요청자 UUID 매개변수를 통해 요청자 정보를 조회할 수 있는 새로운 API 엔드포인트 추가
  * 요청자 ID 및 이름 정보를 반환하는 기능 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->