### PR TITLE
[feat] userId -> uuid 이용 (#93)

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/keyword/dto/request/TeamficialLogRequestDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/dto/request/TeamficialLogRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class TeamficialLogRequestDto {
-    private Long userId;
+    private String userUuid;
 
     @NotBlank(message = "첫 번째 내용은 비어 있을 수 없습니다.")
     private String content1;

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/dto/response/TeamficialLogRequesterResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/dto/response/TeamficialLogRequesterResponseDto.java
@@ -6,6 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class TeamficialLogRequesterResponseDto {
-    private Long requesterId;
     private String requesterName;
 }

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordService.java
@@ -63,7 +63,7 @@ public class KeywordService {
 
     @Transactional
     public void saveBestKeyword(TeamficialLogRequestDto req, String content, String bestKeyword, List<KeywordContentPairDto> results) {
-        User receiver = userService.getUserById(req.getUserId());
+        User receiver = userService.getUserByUuid(req.getUserUuid());
         Keyword keyword = upsertKeyword(receiver, bestKeyword);
 
         keywordCommentService.save(

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
@@ -210,7 +210,6 @@ public class TeamficialLogService {
         User user = userService.getUserByUuid(requesterUuid);
 
         return TeamficialLogRequesterResponseDto.builder()
-                .requesterId(user.getId())
                 .requesterName(user.getName())
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93

## 📝작업 내용

> 팀피셜록 응답 반환 시 보안 문제로 인해 userId -> uuid 이용하는 걸로 수정하였다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 사용자 식별자 체계를 UUID 기반으로 변경하여 시스템 신뢰성을 강화했습니다.
  * 로그 응답 데이터에서 불필요한 필드를 제거하여 데이터 구조를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->