### PR TITLE
pr fix : 팀피셜록 한번 제한 기능 추가

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/keyword/controller/TeamficialLogController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/controller/TeamficialLogController.java
@@ -62,11 +62,12 @@ public class TeamficialLogController {
     }
 
     @PostMapping("/teamficial-log")
-    @Operation(summary = "팀피셜록 작성하기", description = "팀피셜록을 작성하고 키워드,요약을 추출하는 api 입니다.")
+    @Operation(summary = "팀피셜록 작성하기", description = "팀피셜록을 작성하고 키워드, 코멘트 원문을 추출하는 api 입니다.")
     public ApiResponse<TeamficialLogResponseDto> createTeamficialLog(
-            @Valid @RequestBody TeamficialLogRequestDto request) throws IOException {
+            @Valid @RequestBody TeamficialLogRequestDto request,
+            @AuthenticationPrincipal AuthDetails authDetails) throws IOException {
 
-        return ApiResponse.onSuccess(teamficialLogService.createTeamficialLog(request));
+        return ApiResponse.onSuccess(teamficialLogService.createTeamficialLog(authDetails.user(), request));
     }
 
     @GetMapping("/teamficial-log/requester")

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/dto/request/HeadKeywordRequestDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/dto/request/HeadKeywordRequestDto.java
@@ -6,6 +6,5 @@ import java.util.List;
 
 @Getter
 public class HeadKeywordRequestDto {
-
     private List<Long> keywordIds;
 }

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/entity/KeywordCommentSession.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/entity/KeywordCommentSession.java
@@ -8,22 +8,23 @@ import lombok.NoArgsConstructor;
 import teamficial.teamficial_be.domain.user.entity.User;
 import teamficial.teamficial_be.global.entity.BaseEntity;
 
+
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class KeywordComment extends BaseEntity {
+public class KeywordCommentSession extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "keyword_comment_id")
+    @Column(name = "keyword_comment_session_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "keyword_id")
-    private Keyword keyword;
+    @JoinColumn(name = "user_id")
+    private User owner;
 
-    @Lob
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private User writer;
 }

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/repository/KeywordCommentRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/repository/KeywordCommentRepository.java
@@ -9,4 +9,6 @@ import teamficial.teamficial_be.domain.keyword.entity.KeywordComment;
 public interface KeywordCommentRepository extends JpaRepository<KeywordComment, Long> {
 
     Slice<KeywordComment> findAllByKeyword(Keyword keyword, Pageable pageable);
+
+
 }

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/repository/KeywordCommentSessionRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/repository/KeywordCommentSessionRepository.java
@@ -1,0 +1,9 @@
+package teamficial.teamficial_be.domain.keyword.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamficial.teamficial_be.domain.keyword.entity.KeywordCommentSession;
+
+public interface KeywordCommentSessionRepository extends JpaRepository<KeywordCommentSession, Long> {
+
+    boolean existsByOwnerIdAndWriterId(Long ownerId, Long writerId);
+}

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordCommentSessionService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordCommentSessionService.java
@@ -1,0 +1,21 @@
+package teamficial.teamficial_be.domain.keyword.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import teamficial.teamficial_be.domain.keyword.entity.KeywordCommentSession;
+import teamficial.teamficial_be.domain.keyword.repository.KeywordCommentRepository;
+import teamficial.teamficial_be.domain.keyword.repository.KeywordCommentSessionRepository;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordCommentSessionService {
+    private final KeywordCommentSessionRepository keywordCommentSessionRepository;
+
+    public void saveSession(KeywordCommentSession keywordCommentSession) {
+        keywordCommentSessionRepository.save(keywordCommentSession);
+    }
+
+    public boolean existsByOwnerIdAndWriterId(Long ownerId, Long writerId) {
+        return keywordCommentSessionRepository.existsByOwnerIdAndWriterId(ownerId, writerId);
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordService.java
@@ -62,9 +62,8 @@ public class KeywordService {
     }
 
     @Transactional
-    public void saveBestKeyword(TeamficialLogRequestDto req, String content, String bestKeyword, List<KeywordContentPairDto> results) {
-        User receiver = userService.getUserByUuid(req.getUserUuid());
-        Keyword keyword = upsertKeyword(receiver, bestKeyword);
+    public void saveBestKeyword(User owner, TeamficialLogRequestDto req, String content, String bestKeyword, List<KeywordContentPairDto> results) {
+        Keyword keyword = upsertKeyword(owner, bestKeyword);
 
         keywordCommentService.save(
                 KeywordComment.builder()

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/TeamficialLogService.java
@@ -21,6 +21,7 @@ import teamficial.teamficial_be.domain.keyword.dto.response.*;
 import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
 import teamficial.teamficial_be.domain.keyword.entity.Keyword;
 import teamficial.teamficial_be.domain.keyword.entity.KeywordComment;
+import teamficial.teamficial_be.domain.keyword.entity.KeywordCommentSession;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.profile.service.ProfileService;
 import teamficial.teamficial_be.domain.user.entity.User;
@@ -51,6 +52,7 @@ public class TeamficialLogService {
     private final UserService userService;
     private final EmbeddingService embeddingService;
     private final PromptLoadService promptLoadService;
+    private final KeywordCommentSessionService keywordCommentSessionService;
 
     @Transactional(readOnly = true)
     public HeadKeywordResponseDto getHeadKeyword(Long profileId) {
@@ -138,7 +140,13 @@ public class TeamficialLogService {
         return ScrollResponse.of(dtoList);
     }
 
-    public TeamficialLogResponseDto createTeamficialLog(TeamficialLogRequestDto req) throws IOException {
+    @Transactional
+    public TeamficialLogResponseDto createTeamficialLog(User writer, TeamficialLogRequestDto req) throws IOException {
+        User owner = userService.getUserByUuid(req.getUserUuid());
+
+        if (keywordCommentSessionService.existsByOwnerIdAndWriterId(owner.getId(), writer.getId())) {
+            throw new GeneralException(ErrorStatus.CAN_NOT_WRITE_TEAMFICIAL_LOG_OVER_1);
+        }
 
         List<String> contents = List.of(
                 req.getContent1(),
@@ -157,8 +165,15 @@ public class TeamficialLogService {
 
             String bestKeyword = getBestKeyword(vector);
 
-            keywordService.saveBestKeyword(req, content, bestKeyword, results);
+            keywordService.saveBestKeyword(owner, req, content, bestKeyword, results);
         }
+
+        keywordCommentSessionService.saveSession(
+                KeywordCommentSession.builder()
+                        .owner(owner)
+                        .writer(writer)
+                        .build()
+        );
 
         return new TeamficialLogResponseDto(results);
     }
@@ -181,9 +196,8 @@ public class TeamficialLogService {
                 )
         );
 
-        String bestKeyword = (String) searchResponse.getHits().getHits()[0]
+        return (String) searchResponse.getHits().getHits()[0]
                 .getSourceAsMap().get("keyword");
-        return bestKeyword;
     }
 
     private String buildKeywordKnnQuery(float[] embeddingVector) throws IOException {

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/entity/Period.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/entity/Period.java
@@ -12,4 +12,5 @@ public enum Period {
     OVER_SIX_MONTHS("6개월 이상"),
     FLEXIBLE("미정/협의 예정");
     private final String description;
+
 }

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -50,6 +50,9 @@ public enum ErrorStatus implements BaseErrorCode {
     CANNOT_HEAD_KEYWORD_OVER_3(HttpStatus.BAD_REQUEST,"HEADKEYWORD4004","프로필 당 대표키워드는 최대 3개를 넘을 수 없습니다."),
     HEAD_KEYWORD_DUPLICATE(HttpStatus.BAD_REQUEST,"HEADKEYWORD4005","이미 등록된 대표키워드입니다."),
 
+
+    CAN_NOT_WRITE_TEAMFICIAL_LOG_OVER_1(HttpStatus.FORBIDDEN,"KEYWORD_COMMENT5001","해당 유저에게 쓴 팀피셜록이 이미 존재합니다.")
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostQueryPerformanceTest.java
+++ b/src/test/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostQueryPerformanceTest.java
@@ -53,7 +53,7 @@ public class RecruitingPostQueryPerformanceTest {
         Position position = null;
         ProgressWay progressWay = null;
 
-        int pageSize = 20;
+        int pageSize = 9;
 
         // 1) 전체 개수 조회
         Long totalCount = em.createQuery(
@@ -78,6 +78,44 @@ public class RecruitingPostQueryPerformanceTest {
 
         System.out.println("마지막 페이지 조회 시간 : " + (end - start) + " ms");
         System.out.println("조회된 데이터 수       : " + lastPage.getContent().size());
+    }
+
+    @Test
+    void measure_querydsl_middle_page_performance() {
+
+        RecruitingStatus status = null;
+        Position position = null;
+        ProgressWay progressWay = null;
+
+        int pageSize = 9;
+
+        // 1) 전체 개수 조회
+        Long totalCount = em.createQuery(
+                "SELECT COUNT(rp) FROM RecruitingPost rp", Long.class
+        ).getSingleResult();
+
+        // 2) 전체 페이지 수 계산
+        int totalPages = (int) (totalCount == 0 ? 0 : (totalCount - 1) / pageSize + 1);
+
+        // 3) 가운데 페이지 번호 계산 (절반 지점)
+        int middlePageNumber = Math.max(0, totalPages / 2);  // page index는 0부터이므로 1 빼지 않음
+
+        Pageable pageable = PageRequest.of(middlePageNumber, pageSize);
+
+        System.out.println("==== QueryDSL Middle Page Performance Test ====");
+        System.out.println("totalCount         = " + totalCount);
+        System.out.println("pageSize           = " + pageSize);
+        System.out.println("totalPages         = " + totalPages);
+        System.out.println("middlePageNumber   = " + middlePageNumber);
+        System.out.println("----------------------------------------------");
+
+        long start = System.currentTimeMillis();
+        Page<RecruitingPostDto.RecruitingPostsResponseDTO> middlePage =
+                recruitingPostService.getRecruitingPosts(status, position, progressWay, pageable);
+        long end = System.currentTimeMillis();
+
+        System.out.println("중간 페이지 조회 시간 : " + (end - start) + " ms");
+        System.out.println("조회된 데이터 수       : " + middlePage.getContent().size());
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #118 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [ ] 테이블 keyword_comment_session 추가 
- [ ] 팀피셜록 요청시 onwer, writer를 session 테이블에 등록, 이후 같은 onwer, writer를 조회하여 데이터 있으면 오류 출력

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
