### PR TITLE
[feat] 나의 팀 리스트 조회 구현

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/repository/ApplicationRepository.java
@@ -58,6 +58,9 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     boolean existsByUserAndRecruitingPostAndApplicationStatus(User user, RecruitingPost recruitingPost,ApplicationStatus status);
 
-    List<Application> findAllByUserAndRecruitingPostAndApplicationStatus(User user, RecruitingPost recruitingPost,ApplicationStatus status);
 
+    @Query("SELECT ap FROM Application ap " +
+            "JOIN FETCH ap.user "+
+            "WHERE ap.user = :user AND ap.applicationStatus = :applicationStatus")
+    List<Application> findAllByUserAndApplicationStatus(User user, ApplicationStatus applicationStatus);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/application/service/ApplicationService.java
@@ -178,4 +178,8 @@ public class ApplicationService {
     public boolean existApplicationMatched(User user, RecruitingPost recruitingPost) {
         return applicationRepository.existsByUserAndRecruitingPostAndApplicationStatus(user, recruitingPost, ApplicationStatus.MATCHED);
     }
+
+    public List<Application> getAllByUserAndStatus(User user, ApplicationStatus applicationStatus) {
+        return applicationRepository.findAllByUserAndApplicationStatus(user,applicationStatus);
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/controller/MypageController.java
@@ -7,10 +7,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import teamficial.teamficial_be.domain.application.dto.response.ApplicationResponseDto;
 import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
-import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicantResponseDto;
-import teamficial.teamficial_be.domain.myPage.dto.response.CurrentApplicationDetailResponseDto;
-import teamficial.teamficial_be.domain.myPage.dto.response.DashboardResponseDto;
-import teamficial.teamficial_be.domain.myPage.dto.response.MyApplicationResponseDto;
+import teamficial.teamficial_be.domain.myPage.dto.response.*;
 import teamficial.teamficial_be.domain.myPage.service.MypageService;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
 import teamficial.teamficial_be.global.apiPayload.ApiResponse;
@@ -39,6 +36,16 @@ public class MypageController {
                                                                                       @RequestParam(defaultValue = "0") int page,
                                                                                       @RequestParam(defaultValue = "3") int size) {
         PagedResponse<MyApplicationResponseDto> responseDtos = mypageService.getAllApplications(authDetails.user(),page,size,applicationStatus);
+        return ApiResponse.onSuccess(responseDtos);
+    }
+
+    @GetMapping("/my-page/my-teams")
+    @Operation(summary = "나의 팀 리스트 조회하기", description = "마이페이지에서 나의 팀 리스트를 조회하는 API입니다.")
+    public ApiResponse<PagedResponse<MyTeamResponseDto>> getMyTeams(@AuthenticationPrincipal AuthDetails authDetails,
+                                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "3") int size){
+        PagedResponse<MyTeamResponseDto> responseDtos = mypageService.getMyTeams(authDetails.user(),page,size);
+
         return ApiResponse.onSuccess(responseDtos);
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -2,10 +2,7 @@ package teamficial.teamficial_be.domain.myPage.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.application.dto.response.ApplicationResponseDto;
@@ -291,5 +288,39 @@ public class MypageService {
     }
 
 
+    public PagedResponse<MyTeamResponseDto> getMyTeams(User user, int page, int size) {
 
+        //지원한 내역 중 MATCHED 상태인 것들의 게시글
+        List<RecruitingPost> myMatchedPostList = applicationService.getAllByUserAndStatus(user, ApplicationStatus.MATCHED).stream()
+                .map(Application::getRecruitingPost)
+                .toList();
+
+        //내가 작성한 모집글 중 마감된 것
+        List<RecruitingPost> recruitingPostList = recruitingPostService.getAllRecruitingPostsByUserAndStatus(user,RecruitingStatus.CLOSED);
+
+        //두 리스트 합치고 모집 글 최신순으로 페이징
+        List<MyTeamResponseDto> posts = new ArrayList<>();
+
+        myMatchedPostList.forEach(post -> {
+            int totalMembers = confirmedProfileService.getTotalMembers(post);
+            posts.add(MyTeamResponseDto.from(post,totalMembers));
+        });
+
+        recruitingPostList.forEach(post -> {
+            int totalMembers = confirmedProfileService.getTotalMembers(post);
+            posts.add(MyTeamResponseDto.from(post,totalMembers));
+        });
+
+        posts.sort(Comparator.comparing( MyTeamResponseDto::getCreateAt).reversed());
+
+
+        Pageable pageable = PageRequest.of(page, size);
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), posts.size());
+        List<MyTeamResponseDto> pageContent = (start <= end) ? posts.subList(start, end) : List.of();
+
+        Page<MyTeamResponseDto> pageResult = new PageImpl<>(pageContent, pageable, posts.size());
+
+        return PagedResponse.of(pageResult);
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -53,4 +53,10 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
             "ORDER BY rp.deadline ASC " +
             "LIMIT 3")
     List<RecruitingPost> findTop3ByUserOrderByDeadlineAsc(User user);
+
+    @Query("SELECT rp FROM RecruitingPost rp " +
+            "LEFT JOIN FETCH rp.recruitingDetails d " +
+            "JOIN FETCH rp.user " +
+            "WHERE rp.user = :user AND rp.status = :recruitingStatus")
+    List<RecruitingPost> findAllByUserAndStatus(User user, RecruitingStatus recruitingStatus);
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
@@ -258,4 +258,8 @@ public class RecruitingPostService {
     public List<RecruitingPost> getTop3ByUserOrderByDeadlineAsc(User user) {
         return recruitingPostRepository.findTop3ByUserOrderByDeadlineAsc(user);
     }
+
+    public List<RecruitingPost> getAllRecruitingPostsByUserAndStatus(User user, RecruitingStatus recruitingStatus) {
+        return recruitingPostRepository.findAllByUserAndStatus(user,recruitingStatus);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #91

## 📝작업 내용

> 마이페이지에서 나의 팀 전체보기 클릭 시, 페이징처리된 리스트를 조회하는 api를 구현하였다

- [x] 나의 팀 리스트 조회 api 구현

### 스크린샷 (선택)
<img width="747" height="402" alt="image" src="https://github.com/user-attachments/assets/8e1e76c3-6813-4554-88a7-78a09a6976dd" />

🚨추후에 성능 개선 고려

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
