### PR TITLE
[fix] 로컬/배포 트랜잭션 LazyInitializationException 해결

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyTeamResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/dto/response/MyTeamResponseDto.java
@@ -25,10 +25,23 @@ public class MyTeamResponseDto {
     private int totalMembers;
     private LocalDateTime createAt;
 
-    public static MyTeamResponseDto from(RecruitingPost recruitingPost,int totalMembers) {
+    public static MyTeamResponseDto of(RecruitingPost recruitingPost,int totalMembers) {
         List<String> tags = recruitingPost.getRecruitingDetails().stream()
                 .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
                 .toList();
+
+        return MyTeamResponseDto.builder()
+                .postId(recruitingPost.getId())
+                .period(recruitingPost.getPeriod().getDescription())
+                .title(recruitingPost.getTitle())
+                .progressWay(recruitingPost.getProgressWay().getDescription())
+                .tags(tags)
+                .totalMembers(totalMembers)
+                .createAt(recruitingPost.getCreatedAt())
+                .build();
+    }
+
+    public static MyTeamResponseDto from(RecruitingPost recruitingPost,int totalMembers, List<String> tags) {
 
         return MyTeamResponseDto.builder()
                 .postId(recruitingPost.getId())

--- a/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/myPage/service/MypageService.java
@@ -261,7 +261,7 @@ public class MypageService {
                 .filter(app -> app.getApplicationStatus() == ApplicationStatus.MATCHED)
                 .map(app -> {
                     int totalMembers = confirmedProfileService.getTotalMembers(app.getRecruitingPost());
-                    return MyTeamResponseDto.from(app.getRecruitingPost(), totalMembers);
+                    return MyTeamResponseDto.of(app.getRecruitingPost(), totalMembers);
                 })
                 .toList();
 
@@ -270,7 +270,7 @@ public class MypageService {
                 .filter(post -> post.getStatus() == RecruitingStatus.CLOSED)
                 .map(post -> {
                     int totalMembers = confirmedProfileService.getTotalMembers(post);
-                    return MyTeamResponseDto.from(post, totalMembers);
+                    return MyTeamResponseDto.of(post, totalMembers);
                 })
                 .toList();
 
@@ -287,7 +287,7 @@ public class MypageService {
                 .build();
     }
 
-
+    @Transactional(readOnly = true)
     public PagedResponse<MyTeamResponseDto> getMyTeams(User user, int page, int size) {
 
         //지원한 내역 중 MATCHED 상태인 것들의 게시글
@@ -303,12 +303,18 @@ public class MypageService {
 
         myMatchedPostList.forEach(post -> {
             int totalMembers = confirmedProfileService.getTotalMembers(post);
-            posts.add(MyTeamResponseDto.from(post,totalMembers));
+            List<String> tags = post.getRecruitingDetails().stream()
+                    .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
+                    .toList();
+            posts.add(MyTeamResponseDto.from(post,totalMembers, tags));
         });
 
         recruitingPostList.forEach(post -> {
             int totalMembers = confirmedProfileService.getTotalMembers(post);
-            posts.add(MyTeamResponseDto.from(post,totalMembers));
+            List<String> tags = post.getRecruitingDetails().stream()
+                    .map(recruitingDetail -> recruitingDetail.getPosition().getDescription())
+                    .toList();
+            posts.add(MyTeamResponseDto.from(post,totalMembers, tags));
         });
 
         posts.sort(Comparator.comparing( MyTeamResponseDto::getCreateAt).reversed());

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/repository/RecruitingPostRepository.java
@@ -55,7 +55,6 @@ public interface RecruitingPostRepository extends JpaRepository<RecruitingPost, 
     List<RecruitingPost> findTop3ByUserOrderByDeadlineAsc(User user);
 
     @Query("SELECT rp FROM RecruitingPost rp " +
-            "LEFT JOIN FETCH rp.recruitingDetails d " +
             "JOIN FETCH rp.user " +
             "WHERE rp.user = :user AND rp.status = :recruitingStatus")
     List<RecruitingPost> findAllByUserAndStatus(User user, RecruitingStatus recruitingStatus);


### PR DESCRIPTION
## 📝작업 내용

> 로컬에서 테스트할 때는 문제없었으나, 배포 환경에서는 recruitingDetails 조회 시 LazyInitializationException이 발생하였다
-> 조사해본 결과 로컬에서는 트랜잭션이 살아 있을 때 DTO가 생성돼서 Lazy 로딩이 가능하나,
배포 환경에서는 트랜잭션이 종료된 뒤에야 DTO를 생성하여 세션이 닫혀버리는 문제가 있다고한다.

따라서 해당 부분을 dto -> service로직에서 가져와 필드를 저장하는 방식으로 수정했다


### 스크린샷 (선택
<img width="780" height="264" alt="image" src="https://github.com/user-attachments/assets/09341ec1-0480-4081-8e40-460c58c8849a" />


## 💬리뷰 요구사항(선택)

> 비즈니스 로직으로 옮기면 LazyInitializationException가 발생하지않는지?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 최적화**
  * 팀 정보 조회 성능이 개선되었습니다.

* **리팩토링**
  * 팀 응답 데이터 생성 방식이 내부적으로 개선되었습니다.
  * 팀 관련 정보 처리 로직이 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->