### PR TITLE
[hotfix] authDetails null 에러 처리

### DIFF
--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -119,4 +119,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 request
         );
     }
+
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<Object> handleNullPointer(NullPointerException e, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(
+                ErrorStatus._UNAUTHORIZED.getCode(),
+                ErrorStatus._UNAUTHORIZED.getMessage(),
+                null
+        );
+        return new ResponseEntity<>(body, HttpStatus.UNAUTHORIZED);
+
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/global/security/AuthDetailsService.java
+++ b/src/main/java/teamficial/teamficial_be/global/security/AuthDetailsService.java
@@ -25,6 +25,11 @@ public class AuthDetailsService implements UserDetailsService {
             Long id = Long.valueOf(userId);
             User user = userRepository.findById(id)
                     .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+
+            if (user == null) {
+                throw new GeneralException(ErrorStatus.NOT_FOUND_USER);
+            }
+
             return new AuthDetails(user);
         } catch (NumberFormatException e){
             throw new GeneralException(ErrorStatus.TOKEN_INVALID);


### PR DESCRIPTION
## 📝작업 내용

> 팀피셜록 작성 시 로그인을 하지 않은 상태일 때, 로그인 창으로 이동해야하는데
이때의 에러 핸들링이 안되어있어 수정하였다

- [x] authDetails가 null일 경우 에러처리

### 스크린샷 (선택)
<img width="714" height="260" alt="image" src="https://github.com/user-attachments/assets/42bfa862-4019-4dc6-a977-41e6c801faab" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 널 포인터 예외에 대한 오류 처리 로직을 추가했습니다. 이제 해당 예외가 발생할 때 적절한 오류 응답이 반환됩니다.

* **리팩토링**
  * 사용자 조회 로직의 안정성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->