### PR TITLE
[feat] uuid로 프로필 id 리스트 조회 API

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/controller/ProfileController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
+import teamficial.teamficial_be.domain.profile.dto.response.ProfileIdListResponseDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.profile.service.ProfileService;
 import teamficial.teamficial_be.global.apiPayload.ApiResponse;
@@ -33,6 +34,13 @@ public class ProfileController {
     @Operation(summary = "프로필리스트 조회", description = "프로필을 조회하는 API입니다.")
     public ApiResponse<List<ProfileResponseDto>> getProfileList(@AuthenticationPrincipal AuthDetails authDetails) {
         List<ProfileResponseDto> profileResponseDtos = profileService.getProfileList(authDetails.user());
+        return ApiResponse.onSuccess(profileResponseDtos);
+    }
+
+    @GetMapping("/{userUuid}/profile")
+    @Operation(summary = "uuid로 프로필 id 리스트 조회", description = "uuid로 프로필 id 리스트룰 조회하는 API입니다.")
+    public ApiResponse<ProfileIdListResponseDto> getProfileIdList(@PathVariable String userUuid) {
+        ProfileIdListResponseDto profileResponseDtos = profileService.getProfileIdList(userUuid);
         return ApiResponse.onSuccess(profileResponseDtos);
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileIdListResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/dto/response/ProfileIdListResponseDto.java
@@ -1,0 +1,12 @@
+package teamficial.teamficial_be.domain.profile.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ProfileIdListResponseDto {
+    List<Long> profileIdList;
+}

--- a/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/profile/service/ProfileService.java
@@ -8,6 +8,7 @@ import teamficial.teamficial_be.domain.application.entity.ApplicationStatus;
 import teamficial.teamficial_be.domain.application.service.ApplicationService;
 import teamficial.teamficial_be.domain.profile.dto.ProfileStatus;
 import teamficial.teamficial_be.domain.profile.dto.request.ProfileRequestDto;
+import teamficial.teamficial_be.domain.profile.dto.response.ProfileIdListResponseDto;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.profile.entity.Profile;
 import teamficial.teamficial_be.domain.profile.entity.WorkingTime;
@@ -16,6 +17,7 @@ import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingStatus;
 import teamficial.teamficial_be.domain.recruitingPost.service.RecruitingPostService;
 import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.domain.user.service.UserService;
 import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
 import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 import teamficial.teamficial_be.global.apiPayload.exception.handler.NotFoundHandler;
@@ -29,6 +31,7 @@ public class ProfileService {
     private final ProfileRepository profileRepository;
     private final PreSignedUrlService preSignedUrlService;
     private final RecruitingPostService recruitingPostService;
+    private final UserService userService;
 
     @Transactional
     public ProfileResponseDto createProfile(User user, ProfileRequestDto requestDto, String objectKey){
@@ -205,5 +208,17 @@ public class ProfileService {
     public Profile getProfileWithLinks(Long profileId) {
         return profileRepository.findWithLinksById(profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileIdListResponseDto getProfileIdList(String userUuid) {
+        User user = userService.getUserByUuid(userUuid);
+        List<Long> profileIdList = profileRepository.findAllByUserAndIsDeletedFalse(user).stream()
+                .map(Profile::getId)
+                .toList();
+
+        return ProfileIdListResponseDto.builder()
+                .profileIdList(profileIdList)
+                .build();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 다른 사람이 특정 유저의 팀피셜록을 볼 때 uuid로 프로필 id리스트를 넘겨받는 API가 필요하여 구현했습니다

- uuid로 프로필 id 리스트 조회 API
<img width="1092" height="278" alt="image" src="https://github.com/user-attachments/assets/032afcb7-b3d5-4ae8-bcd1-79dcfcdf8b35" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 사용자 계정에 연결된 프로필 ID 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->