### PR TITLE
[feat] 팀피셜록 신고하기 API

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/keyword/dto/response/KeywordCommentResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/dto/response/KeywordCommentResponseDto.java
@@ -10,6 +10,8 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class KeywordCommentResponseDto {
+    @Schema(description = "코멘트 id", example = "1")
+    Long commentId;
     @Schema(description = "코멘트 내용", example="너무 친절해요")
     String comment;
     @Schema(description = "코멘트 생성 시간")
@@ -17,6 +19,7 @@ public class KeywordCommentResponseDto {
 
     public static KeywordCommentResponseDto from(KeywordComment keywordComment) {
         return KeywordCommentResponseDto.builder()
+                .commentId(keywordComment.getId())
                 .comment(keywordComment.getContent())
                 .createdAt(keywordComment.getCreatedAt())
                 .build();

--- a/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordCommentService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/keyword/service/KeywordCommentService.java
@@ -9,6 +9,8 @@ import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
 import teamficial.teamficial_be.domain.keyword.entity.Keyword;
 import teamficial.teamficial_be.domain.keyword.entity.KeywordComment;
 import teamficial.teamficial_be.domain.keyword.repository.KeywordCommentRepository;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
 
 @Service
 @RequiredArgsConstructor
@@ -25,4 +27,8 @@ public class KeywordCommentService {
     }
 
 
+    public KeywordComment getById(Long keywordCommentId) {
+        return keywordCommentRepository.findById(keywordCommentId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_KEYWORD_COMMENT));
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/report/controller/ReportController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/controller/ReportController.java
@@ -1,0 +1,34 @@
+package teamficial.teamficial_be.domain.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import teamficial.teamficial_be.domain.report.dto.ReportRequestDto;
+import teamficial.teamficial_be.domain.report.service.ReportService;
+import teamficial.teamficial_be.global.apiPayload.ApiResponse;
+import teamficial.teamficial_be.global.security.AuthDetails;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "팀피셜록 신고하기 API", description = "유저가 자신에게 달린 팀피셜록을 신고하는 API입니다.")
+    @PostMapping("/reports/{keywordCommentId}")
+    public ApiResponse<String> reportTeamficialLog(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long keywordCommentId,
+            @RequestBody @Valid ReportRequestDto reportRequestDto) {
+
+        reportService.reportTeamficialLog(authDetails.user(), keywordCommentId, reportRequestDto);
+
+        return ApiResponse.onSuccess("신고 내용이 팀피셜에게 전달되었습니다.");
+    }
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/report/controller/ReportController.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/controller/ReportController.java
@@ -19,7 +19,16 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    @Operation(summary = "팀피셜록 신고하기 API", description = "유저가 자신에게 달린 팀피셜록을 신고하는 API입니다.")
+    @Operation(summary = "팀피셜록 신고하기 API", description = """
+            유저가 자신에게 달린 팀피셜록을 신고하는 API입니다. \n
+            ## Request Body
+            `reportType` : HATE_SPEECH, UNSUITABLE_KEYWORD, OTHER 중 택 1 \n
+                - `HATE_SPEECH` : 비방적인 내용입니다. \n
+                - `UNSUITABLE_KEYWORD` : 적합하지 않은 내용의 키워드입니다. \n
+                - `OTHER` : 기타 (직접 입력) \n
+            `reportEtc` : reportType이 기타일 경우, 입력해주세요. \n
+            `content` : 신고 내용
+            """)
     @PostMapping("/reports/{keywordCommentId}")
     public ApiResponse<String> reportTeamficialLog(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/teamficial/teamficial_be/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/dto/ReportRequestDto.java
@@ -1,0 +1,23 @@
+package teamficial.teamficial_be.domain.report.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import teamficial.teamficial_be.domain.report.entity.ReportType;
+
+@Getter
+public class ReportRequestDto {
+    @NotNull(message = "신고 유형은 필수입니다.")
+    ReportType reportType;
+
+    @Schema(example = "신고 유형이 기타일 경우 입력해주세요.")
+    @Size(max = 100)
+    String reportEtc; //신고 유형이 기타일 경우
+
+    @NotBlank(message = "신고 내용은 필수입니다.")
+    @Size(max = 500)
+    String content;
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/dto/ReportRequestDto.java
@@ -10,14 +10,14 @@ import teamficial.teamficial_be.domain.report.entity.ReportType;
 @Getter
 public class ReportRequestDto {
     @NotNull(message = "신고 유형은 필수입니다.")
-    ReportType reportType;
+    private ReportType reportType;
 
     @Schema(example = "신고 유형이 기타일 경우 입력해주세요.")
     @Size(max = 100)
-    String reportEtc; //신고 유형이 기타일 경우
+    private String reportEtc; //신고 유형이 기타일 경우
 
     @NotBlank(message = "신고 내용은 필수입니다.")
     @Size(max = 500)
-    String content;
+    private String content;
 
 }

--- a/src/main/java/teamficial/teamficial_be/domain/report/entity/Report.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/entity/Report.java
@@ -22,7 +22,7 @@ public class Report extends BaseEntity {
     @Column(length = 500, nullable = false)
     private String content;
 
-    private boolean is_applied;
+    private boolean isApplied;
 
     @Column(length = 100)
     private String reportEtc;

--- a/src/main/java/teamficial/teamficial_be/domain/report/entity/Report.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/entity/Report.java
@@ -1,0 +1,35 @@
+package teamficial.teamficial_be.domain.report.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Report extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportType reportType;
+
+    @Column(length = 500, nullable = false)
+    private String content;
+
+    private boolean is_applied;
+
+    @Column(length = 100)
+    private String reportEtc;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/report/entity/ReportType.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/entity/ReportType.java
@@ -1,0 +1,13 @@
+package teamficial.teamficial_be.domain.report.entity;
+
+public enum ReportType {
+    HATE_SPEECH("비방적인 내용입니다."),
+    UNSUITABLE_KEYWORD("적합하지 않은 내용의 키워드입니다."),
+    OTHER("기타 (직접 입력)");
+
+    private final String description;
+
+    ReportType(String description) {this.description = description;}
+
+    public String getDescription() {return description;}
+}

--- a/src/main/java/teamficial/teamficial_be/domain/report/repository/ReportRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package teamficial.teamficial_be.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamficial.teamficial_be.domain.report.entity.Report;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/teamficial/teamficial_be/domain/report/service/ReportService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/service/ReportService.java
@@ -1,0 +1,43 @@
+package teamficial.teamficial_be.domain.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamficial.teamficial_be.domain.keyword.entity.KeywordComment;
+import teamficial.teamficial_be.domain.keyword.service.KeywordCommentService;
+import teamficial.teamficial_be.domain.report.dto.ReportRequestDto;
+import teamficial.teamficial_be.domain.report.entity.Report;
+import teamficial.teamficial_be.domain.report.entity.ReportType;
+import teamficial.teamficial_be.domain.report.repository.ReportRepository;
+import teamficial.teamficial_be.domain.user.entity.User;
+import teamficial.teamficial_be.global.apiPayload.code.status.ErrorStatus;
+import teamficial.teamficial_be.global.apiPayload.exception.GeneralException;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final KeywordCommentService keywordCommentService;
+
+    @Transactional
+    public void reportTeamficialLog(User user, Long keywordCommentId, ReportRequestDto reportRequestDto) {
+        KeywordComment comment = keywordCommentService.getById(keywordCommentId);
+
+        if (!comment.getKeyword().getUser().getId().equals(user.getId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        Report report = Report.builder()
+                .reportType(reportRequestDto.getReportType())
+                .reportEtc(reportRequestDto.getReportType()== ReportType.OTHER? reportRequestDto.getReportEtc() : null)
+                .content(reportRequestDto.getContent())
+                .is_applied(false)
+                .user(user)
+                .build();
+
+        reportRepository.save(report);
+
+        //이메일 전송 로직
+    }
+}

--- a/src/main/java/teamficial/teamficial_be/domain/report/service/ReportService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/service/ReportService.java
@@ -32,7 +32,7 @@ public class ReportService {
                 .reportType(reportRequestDto.getReportType())
                 .reportEtc(reportRequestDto.getReportType()== ReportType.OTHER? reportRequestDto.getReportEtc() : null)
                 .content(reportRequestDto.getContent())
-                .is_applied(false)
+                .isApplied(false)
                 .user(user)
                 .build();
 

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_APPLICAION(HttpStatus.NOT_FOUND,"APPLICATION404","해당 지원을 찾을 수 없습니다."),
     NOT_FOUND_KEYWORD(HttpStatus.NOT_FOUND,"KEYWORD404", "해당 키워드를 찾을 수 없습니다."),
     NOT_FOUND_HEAD_KEYWORD(HttpStatus.NOT_FOUND,"HEADKEYWORD404", "해당 대표 키워드를 찾을 수 없습니다."),
+    NOT_FOUND_KEYWORD_COMMENT(HttpStatus.NOT_FOUND,"KEYWORDCOMMENT404", "해당 키워드 코멘트를 찾을 수 없습니다."),
 
     //로그인 관련 응답
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "LOGIN4001", "토큰이 유효하지 않습니다."),
@@ -51,8 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
     HEAD_KEYWORD_DUPLICATE(HttpStatus.BAD_REQUEST,"HEADKEYWORD4005","이미 등록된 대표키워드입니다."),
     CAN_NOT_WRITE_TEAMFICIAL_LOG_OVER_1(HttpStatus.FORBIDDEN,"KEYWORD_COMMENT5001","해당 유저에게 쓴 팀피셜록이 이미 존재합니다."),
 
+
     //나의 팀 관련 응답
-    TEAM_FORBIDDEN(HttpStatus.FORBIDDEN, "TEAM_FORBIDDEN403", "팀 멤버를 조회할 수 있는 권한이 없습니다.")
+    TEAM_FORBIDDEN(HttpStatus.FORBIDDEN, "TEAM_FORBIDDEN403", "팀 멤버를 조회할 수 있는 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #129

## 📝작업 내용

> 팀피셜록 신고하기 API 구현했습니다.
<img width="725" height="390" alt="스크린샷 2025-12-29 오후 4 11 43" src="https://github.com/user-attachments/assets/b2fedf26-12e7-4a5e-8b9e-fa2b8e387643" />

이메일 전송 로직은 추후 템플릿 정해진 후에 추가하겠습니당

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 신고 기능 추가 — 사용자는 혐오 발언, 부적절한 키워드, 기타(직접 입력)로 댓글을 신고할 수 있습니다.
  * 신고 제출 API 및 저장 처리 도입 — 신고는 서버에 저장되어 검토 대기 상태로 처리됩니다.
  * 댓글 응답에 commentId 포함 — 댓글 응답에 식별자가 추가되어 연동이 더 쉬워졌습니다.

* **버그 수정 / 안정성**
  * 존재하지 않는 댓글 조회 시 적절한 오류 응답 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->