### PR TITLE
[fix] 신고 중복 문제 해결

### DIFF
--- a/src/main/java/teamficial/teamficial_be/TeamficialBeApplication.java
+++ b/src/main/java/teamficial/teamficial_be/TeamficialBeApplication.java
@@ -3,8 +3,10 @@ package teamficial.teamficial_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableScheduling

--- a/src/main/java/teamficial/teamficial_be/domain/report/entity/Report.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/entity/Report.java
@@ -10,6 +10,9 @@ import teamficial.teamficial_be.global.entity.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "reported_comment_id"})
+})
 public class Report extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
@@ -31,7 +34,7 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false)
+    @Column(name = "reported_comment_id", nullable = false)
     private Long reportedCommentId;
 
     public void reportAccept(){

--- a/src/main/java/teamficial/teamficial_be/domain/report/repository/ReportRepository.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/repository/ReportRepository.java
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import teamficial.teamficial_be.domain.report.entity.Report;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-    boolean existsByReportedCommentId(Long keywordCommentId);
+
+    boolean existsByReportedCommentIdAndUserId(Long keywordCommentId, Long userId);
 
     @Query("SELECT r FROM Report r " +
             "WHERE r.isApplied = false ")

--- a/src/main/java/teamficial/teamficial_be/domain/report/service/MailService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/service/MailService.java
@@ -3,14 +3,17 @@ package teamficial.teamficial_be.domain.report.service;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MailService {
@@ -18,12 +21,16 @@ public class MailService {
     private final JavaMailSender mailSender;
     private final TemplateEngine templateEngine;
 
+    @Async
     public void sendReportEmail(String toEmail) {
-        Context context = new Context();
+        try {
+            Context context = new Context();
+            String body = templateEngine.process("report", context);
+            sendHtmlEmail(toEmail, "[팀피셜] 신고가 접수되었습니다", body);
 
-        String body = templateEngine.process("report", context);
-
-        sendHtmlEmail(toEmail, "[팀피셜] 신고가 접수되었습니다", body);
+        } catch (Exception e) {
+            log.error("Failed to send report email to: {}", toEmail, e);
+        }
     }
 
     private void sendHtmlEmail(String to, String subject, String htmlBody) {

--- a/src/main/java/teamficial/teamficial_be/domain/report/service/MailService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/service/MailService.java
@@ -29,7 +29,7 @@ public class MailService {
             sendHtmlEmail(toEmail, "[팀피셜] 신고가 접수되었습니다", body);
 
         } catch (Exception e) {
-            log.error("Failed to send report email to: {}", toEmail, e);
+            log.error("Failed to send report email to", e);
         }
     }
 

--- a/src/main/java/teamficial/teamficial_be/domain/report/service/ReportService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/report/service/ReportService.java
@@ -1,14 +1,13 @@
 package teamficial.teamficial_be.domain.report.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamficial.teamficial_be.domain.keyword.entity.HeadKeyword;
 import teamficial.teamficial_be.domain.keyword.entity.Keyword;
 import teamficial.teamficial_be.domain.keyword.entity.KeywordComment;
-import teamficial.teamficial_be.domain.keyword.service.HeadKeywordService;
 import teamficial.teamficial_be.domain.keyword.service.KeywordCommentService;
 import teamficial.teamficial_be.domain.keyword.service.KeywordService;
 import teamficial.teamficial_be.domain.report.dto.ReportRequestDto;
@@ -27,14 +26,13 @@ public class ReportService {
     private final KeywordCommentService keywordCommentService;
     private final MailService mailService;
     private final KeywordService keywordService;
-    private final HeadKeywordService headKeywordService;
 
     @Transactional
     public void reportTeamficialLog(User user, Long keywordCommentId, ReportRequestDto reportRequestDto) {
         KeywordComment comment = keywordCommentService.getById(keywordCommentId);
 
         //중복 신고 방지
-        if (alreadyExistReport(keywordCommentId)){
+        if (alreadyExistReport(keywordCommentId, user.getId())){
             throw new GeneralException(ErrorStatus.REPORT_DUPLICATE);
         }
 
@@ -52,7 +50,11 @@ public class ReportService {
                 .user(user)
                 .build();
 
-        reportRepository.save(report);
+        try {
+            reportRepository.save(report);
+        } catch (DataIntegrityViolationException e) {
+            throw new GeneralException(ErrorStatus.REPORT_DUPLICATE);
+        }
 
         //이메일 전송 로직
         mailService.sendReportEmail(user.getEmail());
@@ -94,7 +96,7 @@ public class ReportService {
         return reportRepository.findAllByIsApplied(pageable);
     }
 
-    private boolean alreadyExistReport(Long keywordCommentId) {
-        return reportRepository.existsByReportedCommentId(keywordCommentId);
+    private boolean alreadyExistReport(Long keywordCommentId, Long userId) {
+        return reportRepository.existsByReportedCommentIdAndUserId(keywordCommentId, userId);
     }
 }

--- a/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/teamficial/teamficial_be/global/apiPayload/code/status/ErrorStatus.java
@@ -56,7 +56,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TEAM_FORBIDDEN(HttpStatus.FORBIDDEN, "TEAM_FORBIDDEN403", "팀 멤버를 조회할 수 있는 권한이 없습니다."),
 
     //신고 관련 응답
-    REPORT_DUPLICATE(HttpStatus.CONFLICT,"REPORT4001","이미 신고된 코멘트입니다."),
+    REPORT_DUPLICATE(HttpStatus.CONFLICT,"REPORT409","이미 신고된 코멘트입니다."),
     NOT_FOUND_REPORT(HttpStatus.NOT_FOUND, "REPORT404", "해당 신고를 찾을 수 없습니다."),
     REPORT_ALREADY_APPLIED(HttpStatus.CONFLICT,"REPORT4002","이미 반영된 신고입니다.")
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #135

## 📝작업 내용

1. 신고 버튼을 빠르게 여러번 클릭 시, db에 데이터가 누른 횟수만큼 저장되는 문제
-> Transactional과 alreadyExistReport 검사 사이에 Race Condition이 발생한 거 같아 유니크 제약 조건과 try-catch문 추가했습니다

2. 신고 후 API 응답까지 시간이 오래 걸리는 문제
-> 이메일 전송까지 동기적으로 처리되어 오래 걸린 거 같습니다 이메일 전송은 Async처리 했습니다.

### 스크린샷
<img width="1081" height="393" alt="image" src="https://github.com/user-attachments/assets/8783f205-a24c-4750-b71e-5cfa293501fe" />
스웨거로 더블클릭하며 테스트해본 결과 디비에도 한번만 저장되는 거 확인했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 사용자별 중복 리포트 제출 방지 로직 강화(중복 검증 및 저장 시 제약 위반 처리)
  * 리포트 이메일 전송 실패 시 예외를 내부에서 처리하도록 개선

* **개선 사항**
  * 애플리케이션 수준 비동기 처리 활성화로 전반적 응답성 향상
  * 이메일 알림 전송을 비동기로 실행해 성능 최적화
  * 관련 오류 코드 값 정비 및 데이터 무결성 검증 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->