### PR TITLE
pr fix : 단일 게시글 조회 응답 dto 수정 - objectkey, imageurl 추가

### DIFF
--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/RecruitingPostDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import teamficial.teamficial_be.domain.profile.dto.response.ProfileResponseDto;
 import teamficial.teamficial_be.domain.recruitingDetail.entity.RecruitingDetail;
+import teamficial.teamficial_be.domain.recruitingPost.dto.response.PostImageResponseDto;
 import teamficial.teamficial_be.domain.recruitingPost.entity.Period;
 import teamficial.teamficial_be.domain.recruitingPost.entity.ProgressWay;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
@@ -177,12 +178,13 @@ public class RecruitingPostDto {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm:ss")
         private LocalDateTime createdAt;
         private long dDay;
-        private List<String> imageUrls;
+
+        private List<PostImageResponseDto> images;
         private List<RecruitingPositionDto> recruitingPositions;
         private boolean alreadyApplied;
         private boolean isWriter;
 
-        public static RecruitingPostDetailResponseDTO from(RecruitingPost post, List<RecruitingDetail> recruitingDetails, List<String> imageUrls, long dDay, boolean alreadyApplied, boolean isWriter) {
+        public static RecruitingPostDetailResponseDTO from(RecruitingPost post, List<RecruitingDetail> recruitingDetails, List<PostImageResponseDto> images, long dDay, boolean alreadyApplied, boolean isWriter) {
             return RecruitingPostDetailResponseDTO.builder()
                     .postId(post.getId())
                     .writerUserId(post.getUser().getId())
@@ -207,7 +209,7 @@ public class RecruitingPostDto {
                     )
                     .createdAt(post.getCreatedAt())
                     .dDay(dDay)
-                    .imageUrls(imageUrls)
+                    .images(images)
                     .alreadyApplied(alreadyApplied)
                     .isWriter(isWriter)
                     .build();

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/response/PostImageResponseDto.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/dto/response/PostImageResponseDto.java
@@ -1,0 +1,15 @@
+package teamficial.teamficial_be.domain.recruitingPost.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostImageResponseDto {
+
+    private String imageUrl;
+    private String objectKey;
+
+}

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/PostImageService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/PostImageService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamficial.teamficial_be.domain.profile.service.PreSignedUrlService;
+import teamficial.teamficial_be.domain.recruitingPost.dto.response.PostImageResponseDto;
 import teamficial.teamficial_be.domain.recruitingPost.entity.PostImage;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
 import teamficial.teamficial_be.domain.recruitingPost.repository.PostImageRepository;
@@ -96,4 +97,17 @@ public class PostImageService {
         postImageRepository.saveAll(images);
     }
 
+
+    public List<PostImageResponseDto> getPostImages(Long postId) {
+
+        List<PostImage> images =
+                postImageRepository.findByRecruitingPostIdOrderByImageOrder(postId);
+
+        return images.stream()
+                .map(img -> PostImageResponseDto.builder()
+                        .imageUrl(preSignedUrlService.getPublicUrl(img.getObjectKey()))
+                        .objectKey(img.getObjectKey())
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
+++ b/src/main/java/teamficial/teamficial_be/domain/recruitingPost/service/RecruitingPostService.java
@@ -15,6 +15,7 @@ import teamficial.teamficial_be.domain.recruitingDetail.entity.RecruitingDetail;
 import teamficial.teamficial_be.domain.recruitingDetail.repository.RecruitingDetailRepository;
 import teamficial.teamficial_be.domain.recruitingPost.dto.RecruitingPostDto;
 import teamficial.teamficial_be.domain.recruitingPost.dto.RecruitingPostPagingDto;
+import teamficial.teamficial_be.domain.recruitingPost.dto.response.PostImageResponseDto;
 import teamficial.teamficial_be.domain.recruitingPost.entity.PostImage;
 import teamficial.teamficial_be.domain.recruitingPost.entity.ProgressWay;
 import teamficial.teamficial_be.domain.recruitingPost.entity.RecruitingPost;
@@ -185,7 +186,8 @@ public class RecruitingPostService {
         List<RecruitingDetail> recruitingDetails =
                 recruitingDetailRepository.findByRecruitingPostId(postId);
 
-        List<String> imageUrls = postImageService.getPostImageUrls(postId);
+        List<PostImageResponseDto> images =
+                postImageService.getPostImages(postId);
 
         boolean alreadyApplied = false;
         boolean isWriter = false;
@@ -197,7 +199,7 @@ public class RecruitingPostService {
             isWriter = post.isWriter(user);
         }
 
-        return RecruitingPostDto.RecruitingPostDetailResponseDTO.from(post, recruitingDetails, imageUrls, dDay, alreadyApplied,isWriter);
+        return RecruitingPostDto.RecruitingPostDetailResponseDTO.from(post, recruitingDetails, images, dDay, alreadyApplied,isWriter);
     }
 
     public void validatePostOwner(User user, RecruitingPost recruitingPost) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #146 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [ ] 작업 내용 1
- [ ] 작업 내용 2

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 게시물 이미지 데이터 구조를 개선했습니다. 이미지 정보를 단순 문자열에서 객체 기반으로 변경하여 더 풍부한 메타데이터 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->